### PR TITLE
Add todo list page

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,11 +184,9 @@ npx prisma migrate dev --name init
 8. Run the seed script to populate the database with initial data:
 
 ```bash
-npx ts-node --compiler-options {"module":"CommonJS"} prisma/seed.ts
+npx ts-node --compiler-options '{"module":"CommonJS"}' prisma/seed.ts
 ```
 
 ### Note
 
 If you encounter an error stating that a folder called `prisma` already exists in your project when running `npx prisma init`, it is expected. The `prisma` folder and its contents have already been set up in this project. You can skip the `npx prisma init` step and proceed with the other steps.
-
-9. If you encounter an error stating that the table `public.User` does not exist in the current database when running the seed script, it may be because the migrations have not been applied. Make sure to run the `npx prisma migrate dev --name init` command before running the seed script.

--- a/src/actions/getTodos.ts
+++ b/src/actions/getTodos.ts
@@ -1,0 +1,7 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export async function getTodos() {
+  return await prisma.todo.findMany();
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,17 @@
-export default function Home() {
+import { getTodos } from '../actions/getTodos';
+
+export default async function Home() {
+  const todos = await getTodos();
+
   return (
     <div className="grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <h1 className="text-4xl font-bold">Todo App</h1>
+        <ul>
+          {todos.map((todo) => (
+            <li key={todo.id}>{todo.title}</li>
+          ))}
+        </ul>
       </main>
     </div>
   );


### PR DESCRIPTION
Fixes #8

Add server actions to retrieve todos and display them on the home page.

* Create `src/actions/getTodos.ts` to define and export the `getTodos` function that retrieves todos from the database.
* Update `src/app/page.tsx` to import and use the `getTodos` function to fetch and display the list of todos on the home page.
* Update `README.md` to correct the seed command and remove the duplicated number 9.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/9?shareId=78193ec5-1b90-4cce-810b-941ba3174c6a).