### PR TITLE
Add error handling for todo.findMany

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prisma": "^4.16.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hot-toast": "^2.3.0"
+    "react-hot-toast": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "next": "15.1.3",
     "prisma": "^4.16.2",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-hot-toast": "^2.3.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/actions/getTodos.ts
+++ b/src/actions/getTodos.ts
@@ -1,7 +1,0 @@
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
-
-export async function getTodos() {
-  return await prisma.todo.findMany();
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { Toaster } from "react-hot-toast";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        <Toaster />
         {children}
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,17 @@
-import { getTodos } from '../actions/getTodos';
+import { PrismaClient } from '@prisma/client';
+import { toast } from 'react-hot-toast';
+
+const prisma = new PrismaClient();
 
 export default async function Home() {
-  const todos = await getTodos();
+  let todos = [];
+
+  try {
+    todos = await prisma.todo.findMany();
+  } catch (error) {
+    console.error(error);
+    toast.error('Failed to fetch todos');
+  }
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-8 pb-20 gap-16 sm:p-20">


### PR DESCRIPTION
Fixes #19

Add error handling for `prisma.todo.findMany()` and configure `react-hot-toast` for error messages.

* Modify `src/app/page.tsx` to use `prisma.todo.findMany()` directly with a try-catch block to handle errors and show error toast messages using `react-hot-toast`.
* Remove `src/actions/getTodos.ts` as it is no longer needed.
* Modify `src/app/layout.tsx` to include the `Toaster` component from `react-hot-toast`.
* Update `package.json` to add `react-hot-toast` as a dependency.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/20?shareId=fa0713d6-ad7e-4304-a656-08d0a5896b5a).