### PR TITLE
Fix prisma and upgrade packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@prisma/client": "^4.16.2",
+    "@prisma/client": "^6.1.0",
     "next": "15.1.3",
-    "prisma": "^4.16.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.5.1"
@@ -25,6 +24,7 @@
     "eslint": "^9",
     "eslint-config-next": "15.1.3",
     "postcss": "^8",
+    "prisma": "^6.1.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }


### PR DESCRIPTION
Fixes #21

Move `prisma` to dev dependencies and upgrade packages.

* Move `prisma` from `dependencies` to `devDependencies` in `package.json`
* Upgrade `@prisma/client` to version `^6.1.0` in `package.json`
* Upgrade all outdated packages to their latest versions in `package.json`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/22?shareId=d353700f-8aab-4146-893e-e323ea612cb3).