### PR TITLE
Fix todos type

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,10 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Todo } from '@prisma/client';
 import { toast } from 'react-hot-toast';
 
 const prisma = new PrismaClient();
 
 export default async function Home() {
-  let todos = [];
+  let todos: Todo[] = [];
 
   try {
     todos = await prisma.todo.findMany();


### PR DESCRIPTION
Fixes #24

Fix the warning "Variable 'todos' implicitly has type 'any[]' in some locations where its type cannot be determined" in `src/app/page.tsx`.

* Import `Todo` type from `@prisma/client` at the top of the file.
* Type the `todos` variable as `Todo[]` at line 7.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/25?shareId=4c46ba39-b761-4847-9cea-3e745a64a4e6).