### PR TITLE
Fix inspectPrismaError function to remove error.code for specific Prisma errors

### DIFF
--- a/src/utils/prismaErrorUtils.ts
+++ b/src/utils/prismaErrorUtils.ts
@@ -4,9 +4,9 @@ export function inspectPrismaError(error: unknown): string {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     return `Known Request Error: ${error.code} - ${error.name} - ${error.message}`;
   } else if (error instanceof Prisma.PrismaClientUnknownRequestError) {
-    return `Unknown Request Error: ${error.code} - ${error.name} - ${error.message}`;
+    return `Unknown Request Error: ${error.name} - ${error.message}`;
   } else if (error instanceof Prisma.PrismaClientRustPanicError) {
-    return `Rust Panic Error: ${error.code} - ${error.name} - ${error.message}`;
+    return `Rust Panic Error: ${error.name} - ${error.message}`;
   } else {
     return `Unknown error: ${error}`;
   }


### PR DESCRIPTION
Fixes #30

Update `inspectPrismaError` function in `src/utils/prismaErrorUtils.ts` to remove `error.code` for `PrismaClientUnknownRequestError` and `PrismaClientRustPanicError`.

* Remove `error.code` from the error message for `PrismaClientUnknownRequestError`.
* Remove `error.code` from the error message for `PrismaClientRustPanicError`.
* Retain `error.code` in the error message for `PrismaClientKnownRequestError`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/31?shareId=c9ebb565-7a5b-4deb-8a45-da4b0a40a212).