### PR TITLE
Tidy up Prisma setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,31 @@ services:
       POSTGRES_DB: devdb
     volumes:
       - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB} || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  app:
+    image: node:20
+    tty: true
+    stdin_open: true
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: >
+      sh -c "
+      set -eux &&
+      npm run prisma:migrate &&
+      npm run prisma:seed
+      "
+    environment:
+      DATABASE_URL: postgres://devuser:devpassword@postgres:5432/devdb
+    volumes:
+      - .:/app
+    working_dir: /app
+    ports:
+      - "3000:3000"
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
-  postgres:
+  db:
     image: postgres:latest
+    container_name: postgres-container
     ports:
       - "5432:5432"
     environment:
@@ -14,12 +15,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-  app:
+  migration:
     image: node:20
-    tty: true
-    stdin_open: true
+    container_name: prisma-migration-container
     depends_on:
-      postgres:
+      db:
         condition: service_healthy
     command: >
       sh -c "
@@ -29,12 +29,14 @@ services:
       npm run prisma:seed
       "
     environment:
-      DATABASE_URL: postgres://devuser:devpassword@postgres:5432/devdb
+      DATABASE_URL: postgres://devuser:devpassword@db:5432/devdb
     volumes:
       - .:/app
     working_dir: /app
     ports:
       - "3000:3000"
+    stdin_open: true # Keeps stdin open in case any prompts happen
+    tty: true # Allocates a pseudo-terminal for output formatting
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,8 +33,6 @@ services:
     volumes:
       - .:/app
     working_dir: /app
-    ports:
-      - "3000:3000"
     stdin_open: true # Keeps stdin open in case any prompts happen
     tty: true # Allocates a pseudo-terminal for output formatting
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     command: >
       sh -c "
       set -eux &&
+      npm install &&
       npm run prisma:migrate &&
       npm run prisma:seed
       "

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prisma:migrate": "npx prisma migrate dev --name init",
+    "prisma:seed": "npx ts-node --compiler-options '{\"module\":\"CommonJS\"}' prisma/seed.ts"
   },
   "dependencies": {
     "@prisma/client": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postcss": "^8",
     "prisma": "^6.1.0",
     "tailwindcss": "^3.4.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5"
   }
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,8 +3,10 @@ import { PrismaClient } from '@prisma/client';
 const prisma = new PrismaClient();
 
 async function main() {
-  const user1 = await prisma.user.create({
-    data: {
+  const user1 = await prisma.user.upsert({
+    where: { email: 'user1@example.com' },
+    update: {},
+    create: {
       email: 'user1@example.com',
       name: 'User One',
       todos: {
@@ -16,8 +18,10 @@ async function main() {
     },
   });
 
-  const user2 = await prisma.user.create({
-    data: {
+  const user2 = await prisma.user.upsert({
+    where: { email: 'user2@example.com' },
+    update: {},
+    create: {
       email: 'user2@example.com',
       name: 'User Two',
       todos: {

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -3,8 +3,8 @@
 import { Prisma } from '@prisma/client';
 import { redirect } from 'next/navigation';
 
-import { getCookie } from '@/utils/cookieUtils';
 import { prisma } from '@/lib/prisma';
+import { getCookie } from '@/utils/cookieUtils';
 
 type CreateTodoData = Prisma.TodoCreateInput;
 

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -1,11 +1,10 @@
 'use server';
 
-import { Prisma,PrismaClient } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { redirect } from 'next/navigation';
 
 import { getCookie } from '@/utils/cookieUtils';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 type CreateTodoData = Prisma.TodoCreateInput;
 

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -6,3 +6,6 @@ export const prisma =
   globalForPrisma.prisma || new PrismaClient();
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+// This code is from the official documentation
+// https://www.prisma.io/docs/orm/more/help-and-troubleshooting/nextjs-help

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,7 +1,7 @@
 import { Todo } from '@prisma/client';
 
-import { inspectPrismaError } from '@/utils/prismaErrorUtils';
 import { prisma } from '@/lib/prisma';
+import { inspectPrismaError } from '@/utils/prismaErrorUtils';
 
 type TodoResponse = {
   todos?: Todo[];

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,8 +1,7 @@
-import { PrismaClient, Todo } from '@prisma/client';
+import { Todo } from '@prisma/client';
 
 import { inspectPrismaError } from '@/utils/prismaErrorUtils';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 type TodoResponse = {
   todos?: Todo[];


### PR DESCRIPTION
Fixes #38

Refactor Prisma setup to use a single instance of `PrismaClient` and improve Prisma migrate and seed scripts.

* **Prisma Setup:**
  - Create `src/lib/prisma.ts` with the recommended setup for `PrismaClient`.
  - Remove existing `PrismaClient` instances in `src/actions/todos.ts` and `src/services/todoService.ts`.
  - Import `prisma` from `@/lib/prisma` in `src/actions/todos.ts` and `src/services/todoService.ts`.

* **Prisma Migrate and Seed Scripts:**
  - Add npm scripts in `package.json` for `npx prisma migrate dev --name init` and `npx ts-node --compiler-options '{"module":"CommonJS"}' prisma/seed.ts`.
  - Update `docker-compose.yml` to run Prisma migrate and seed automatically when running `docker compose up`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/39?shareId=63bc7baf-2c11-451d-8d84-063c0c2d378f).