### PR TITLE
Add zod validation to form fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "15.1.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-hot-toast": "^2.5.1"
+    "react-hot-toast": "^2.5.1",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -10,11 +10,15 @@ import { getCookie } from '@/utils/cookieUtils';
 type CreateTodoData = Prisma.TodoCreateInput;
 
 const schema = z.object({
-  title: z.string().min(3, { message: 'Title is required' }),
+  title: z.string().min(3, { message: 'Title must be at least 3 characters' }),
   completed: z.boolean().optional(),
 });
 
-export async function createTodoAction(formData: FormData) {
+// use only fieldErrors and skip not so useful formErrors
+type TodoFieldErrors = z.inferFlattenedErrors<typeof schema>['fieldErrors'];;
+export type TodoErrors = { "errors": TodoFieldErrors }
+
+export async function createTodoAction(prevState: TodoErrors, formData: FormData) {
   const title = formData.get('title') as string;
   const completed = formData.get('completed') === 'true';
   const userId = await getCookie('guest_user_id');

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useActionState } from 'react';
-import { createTodoAction } from '@/actions/todos';
+import { createTodoAction, TodoErrors } from '@/actions/todos';
 
-const initialState = {
+const initialState: TodoErrors = {
   errors: {},
 };
 

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -1,15 +1,23 @@
 'use client';
 
+import { useActionState } from 'react';
 import { createTodoAction } from '@/actions/todos';
 
+const initialState = {
+  errors: {},
+};
+
 const TodoForm = () => {
+  const [state, formAction, pending] = useActionState(createTodoAction, initialState);
+
   return (
-    <form action={createTodoAction} className="flex flex-col gap-4">
+    <form action={formAction} className="flex flex-col gap-4">
       <div className="form-control">
         <label htmlFor="title" className="label">
           <span className="label-text">Title:</span>
         </label>
         <input type="text" id="title" name="title" className="input input-bordered" required />
+        {state.errors?.title && <p className="text-red-500">{state.errors.title}</p>}
       </div>
       <div className="form-control">
         <label htmlFor="completed" className="label cursor-pointer">
@@ -17,7 +25,7 @@ const TodoForm = () => {
           <input type="checkbox" id="completed" name="completed" className="checkbox" />
         </label>
       </div>
-      <button type="submit" className="btn btn-primary">Create Todo</button>
+      <button type="submit" className="btn btn-primary" disabled={pending}>Create Todo</button>
     </form>
   );
 };

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useActionState } from 'react';
+
 import { createTodoAction, TodoErrors } from '@/actions/todos';
 
 const initialState: TodoErrors = {


### PR DESCRIPTION
Fixes #40

Add server-side validation using zod for form fields before mutating the data.

* Add zod as a dependency in `package.json`.
* Import `z` from `zod` in `src/actions/todos.ts`.
* Define a schema for `title` and `completed` fields using zod in `src/actions/todos.ts`.
* Validate form data using the schema before creating a new todo in `src/actions/todos.ts`.
* Return validation errors if the form data is invalid in `src/actions/todos.ts`.
* Import `useActionState` from `react` in `src/components/TodoForm.tsx`.
* Use `useActionState` to handle form submission and display validation errors in `src/components/TodoForm.tsx`.
* Disable the submit button while the form is pending in `src/components/TodoForm.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/41?shareId=5c26eaee-0c79-4ffe-a976-35a80e3f4329).