### PR TITLE
Cleanup zod types and validation logic

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -3,8 +3,8 @@
 import { redirect } from 'next/navigation';
 
 import { prisma } from '@/lib/prisma';
+import { TodoErrors, TodoSchema } from '@/models/todo';
 import { getCookie } from '@/utils/cookieUtils';
-import { TodoSchema, TodoErrors } from '@/models/todo';
 
 export async function createTodoAction(prevState: TodoErrors, formData: FormData) {
   const userId = await getCookie('guest_user_id');

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -1,34 +1,22 @@
 'use server';
 
-import { Prisma } from '@prisma/client';
 import { redirect } from 'next/navigation';
-import { z } from 'zod';
 
 import { prisma } from '@/lib/prisma';
 import { getCookie } from '@/utils/cookieUtils';
-
-type CreateTodoData = Prisma.TodoCreateInput;
-
-const schema = z.object({
-  title: z.string().min(3, { message: 'Title must be at least 3 characters' }),
-  completed: z.boolean().optional(),
-});
-
-// use only fieldErrors and skip not so useful formErrors
-type TodoFieldErrors = z.inferFlattenedErrors<typeof schema>['fieldErrors'];;
-export type TodoErrors = { "errors": TodoFieldErrors }
+import { TodoSchema, TodoErrors } from '@/models/todo';
 
 export async function createTodoAction(prevState: TodoErrors, formData: FormData) {
-  const title = formData.get('title') as string;
-  const completed = formData.get('completed') === 'true';
   const userId = await getCookie('guest_user_id');
-  const createdAt = new Date();
 
   if (!userId) {
     throw new Error('User ID not found in cookies');
   }
 
-  const validatedFields = schema.safeParse({ title, completed });
+  const validatedFields = TodoSchema.safeParse({
+    title: formData.get('title') as string,
+    completed: formData.get('completed') === 'true',
+  });
 
   if (!validatedFields.success) {
     return {
@@ -36,16 +24,12 @@ export async function createTodoAction(prevState: TodoErrors, formData: FormData
     };
   }
 
-  const newTodo: CreateTodoData = {
-    title,
-    completed,
-    user: { connect: { id: Number(userId) } },
-    createdAt,
-    updatedAt: createdAt,
-  };
-
   await prisma.todo.create({
-    data: newTodo,
+    data: {
+      title: validatedFields.data.title,
+      completed: validatedFields.data.completed,
+      user: { connect: { id: Number(userId) } },
+    },
   });
 
   redirect('/');

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -2,7 +2,8 @@
 
 import { useActionState } from 'react';
 
-import { createTodoAction, TodoErrors } from '@/actions/todos';
+import { createTodoAction } from '@/actions/todos';
+import { TodoErrors } from '@/models/todo';
 
 const initialState: TodoErrors = {
   errors: {},

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const TodoSchema = z.object({
+  title: z.string().min(3, { message: 'Title must be at least 3 characters' }),
+  completed: z.boolean().optional(),
+});
+
+// use only fieldErrors and skip not so useful formErrors
+export type TodoFieldErrors = z.inferFlattenedErrors<typeof TodoSchema>['fieldErrors'];
+export type TodoErrors = { errors: TodoFieldErrors };


### PR DESCRIPTION
Fixes #42

Clean up type definitions and validation logic in `src/actions/todos.ts` and move them to `src/models/todo.ts`.

* Add `src/models/todo.ts` with `TodoSchema`, `type TodoFieldErrors`, and `export type TodoErrors`.
* Remove `type CreateTodoData`, `const newTodo`, `schema`, `type TodoFieldErrors`, and `export type TodoErrors` from `src/actions/todos.ts`.
* Update `createTodoAction` in `src/actions/todos.ts` to find `userId` from cookie first and check its existence, and use `formData` in `safeParse` argument directly.
* Update imports in `src/components/TodoForm.tsx` to reflect changes in `src/models/todo.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/43?shareId=b884f352-b438-40e5-a549-2ba2c64e6f59).