### PR TITLE
Keep form input state when Zod error

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -2,21 +2,27 @@
 
 import { redirect } from 'next/navigation';
 
-import { TodoErrors } from '@/models/todo';
-import { saveTodo, validateTodo } from '@/services/todoService';
+import { TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
+import { saveTodo } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 
-export async function createTodoAction(prevState: TodoErrors, formData: FormData) {
+export async function createTodoAction(prevState: TodoFormState, formData: FormData) {
   const userId = await getCookie('guest_user_id');
 
   if (!userId) {
     throw new Error('User ID not found in cookies');
   }
 
-  const validatedFields = validateTodo(formData);
+  const todoFormData: TodoSchemaType = {
+    title: `${formData.get('title')}`,
+    completed: formData.get('completed') === 'on',
+  };
+  const validatedFields = TodoSchema.safeParse(todoFormData);
 
   if (!validatedFields.success) {
     return {
+      ...prevState,
+      data: { ...todoFormData },
       errors: validatedFields.error.flatten().fieldErrors,
     };
   }

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -3,14 +3,16 @@
 import { useActionState } from 'react';
 
 import { createTodoAction } from '@/actions/todos';
-import { TodoErrors } from '@/models/todo';
+import { TodoFormState } from '@/models/todo';
 
-const initialState: TodoErrors = {
+const initialState: TodoFormState = {
+  data: { title: "", completed: false },
   errors: {},
 };
 
 const TodoForm = () => {
   const [state, formAction, pending] = useActionState(createTodoAction, initialState);
+  const { title, completed } = state.data;
 
   return (
     <form action={formAction} className="flex flex-col gap-4">
@@ -18,13 +20,13 @@ const TodoForm = () => {
         <label htmlFor="title" className="label">
           <span className="label-text">Title:</span>
         </label>
-        <input type="text" id="title" name="title" className="input input-bordered" required />
+        <input type="text" id="title" name="title" className="input input-bordered" required defaultValue={title} />
         {state.errors?.title && <p className="text-red-500">{state.errors.title}</p>}
       </div>
       <div className="form-control">
         <label htmlFor="completed" className="label cursor-pointer">
           <span className="label-text">Completed:</span>
-          <input type="checkbox" id="completed" name="completed" className="checkbox" />
+          <input type="checkbox" id="completed" name="completed" className="checkbox" defaultChecked={completed} />
         </label>
       </div>
       <button type="submit" className="btn btn-primary" disabled={pending}>Create Todo</button>

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -10,6 +10,10 @@ export type TodoSchemaType = z.infer<typeof TodoSchema>;
 
 // use only fieldErrors and skip not so useful formErrors
 export type TodoFieldErrors = z.inferFlattenedErrors<typeof TodoSchema>['fieldErrors'];
-export type TodoErrors = { errors: TodoFieldErrors };
 
-export type TodoCreateInput = Prisma.TodoCreateInput
+export type TodoFormState = {
+  data: TodoSchemaType,
+  errors: TodoFieldErrors,
+};
+
+export type TodoCreateInput = Prisma.TodoCreateInput;

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,6 +1,6 @@
 import { Todo } from '@prisma/client';
 
-import { TodoSchema, TodoSchemaType } from '@/models/todo';
+import { TodoSchemaType } from '@/models/todo';
 import { createTodo, findAllByUserId } from '@/repositories/todo_repository';
 import { inspectPrismaError } from '@/utils/prismaErrorUtils';
 
@@ -22,13 +22,6 @@ export async function fetchTodos(guestUserId: string | undefined): Promise<TodoR
     const detailedError = inspectPrismaError(error);
     return { error: detailedError };
   }
-}
-
-export function validateTodo(formData: FormData) {
-  return TodoSchema.safeParse({
-    title: formData.get('title') as string,
-    completed: formData.get('completed') === 'true',
-  });
 }
 
 export async function saveTodo(data: TodoSchemaType, userId: number) {


### PR DESCRIPTION
Fixes #48

Update code to keep form input state data when a Zod error occurs.

* **src/models/todo.ts**
  - Remove `TodoErrors` and define `TodoFormState` with `data` and `errors`.

* **src/actions/todos.ts**
  - Import `TodoFormState` and `TodoSchemaType`.
  - Remove `validateTodo` function.
  - Add logic to return form data and errors on validation failure.

* **src/components/TodoForm.tsx**
  - Import `TodoFormState`.
  - Update initial state to use `TodoFormState`.
  - Extract form data after `useActionState`.
  - Use extracted data in input `defaultValue` and `defaultChecked`.

* **src/services/todoService.ts**
  - Remove unused `validateTodo` and `TodoSchema` import.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/49?shareId=d6a6ee7b-6713-4f8a-9f3f-0d7fe19193df).