### PR TITLE
Refactor createTodoAction

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation';
 
-import { TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
+import { TodoFormState } from '@/models/todo';
 import { saveTodo } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 
@@ -13,21 +13,14 @@ export async function createTodoAction(prevState: TodoFormState, formData: FormD
     throw new Error('User ID not found in cookies');
   }
 
-  const todoFormData: TodoSchemaType = {
-    title: `${formData.get('title')}`,              // empty string if not defined
-    completed: formData.get('completed') === 'on',  // checkbox value is on/off
-  };
-  const validatedFields = TodoSchema.safeParse(todoFormData);
+  const result = await saveTodo(formData, Number(userId));
 
-  if (!validatedFields.success) {
+  if (!result.success) {
     return {
       ...prevState,
-      data: { ...todoFormData },
-      errors: validatedFields.error.flatten().fieldErrors,
+      ...result,
     };
   }
-
-  await saveTodo(validatedFields.data, Number(userId));
 
   redirect('/');
 }

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -6,8 +6,10 @@ import { createTodoAction } from '@/actions/todos';
 import { TodoFormState } from '@/models/todo';
 
 const initialState: TodoFormState = {
+  success: false,
   data: { title: "", completed: false },
-  errors: {},
+  zodErrors: {},
+  prismaError: "",
 };
 
 const TodoForm = () => {
@@ -21,7 +23,7 @@ const TodoForm = () => {
           <span className="label-text">Title:</span>
         </label>
         <input type="text" id="title" name="title" className="input input-bordered" required defaultValue={title} />
-        {state.errors?.title && <p className="text-red-500">{state.errors.title}</p>}
+        {state.zodErrors?.title && <p className="text-red-500">{state.zodErrors.title}</p>}
       </div>
       <div className="form-control">
         <label htmlFor="completed" className="label cursor-pointer">
@@ -29,6 +31,7 @@ const TodoForm = () => {
           <input type="checkbox" id="completed" name="completed" className="checkbox" defaultChecked={completed} />
         </label>
       </div>
+      {state.prismaError && <p className="text-red-500">{state.prismaError}</p>}
       <button type="submit" className="btn btn-primary" disabled={pending}>Create Todo</button>
     </form>
   );

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -12,8 +12,10 @@ export type TodoSchemaType = z.infer<typeof TodoSchema>;
 type TodoFieldErrors = z.inferFlattenedErrors<typeof TodoSchema>['fieldErrors'];
 
 export type TodoFormState = {
+  success: boolean,
   data: TodoSchemaType,
-  errors: TodoFieldErrors,
+  zodErrors: TodoFieldErrors,
+  prismaError: string,
 };
 
 export type TodoCreateInput = Prisma.TodoCreateInput;

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -32,12 +32,17 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
 
   const validatedFields = TodoSchema.safeParse(todoFormData);
 
+  const defaultResponse: TodoFormState = {
+    success: false,
+    data: todoFormData,
+    zodErrors: {},
+    prismaError: "",
+  };
+
   if (!validatedFields.success) {
     return {
-      success: false,
-      data: todoFormData,
+      ...defaultResponse,
       zodErrors: validatedFields.error.flatten().fieldErrors,
-      prismaError: "",
     };
   }
 
@@ -47,18 +52,14 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
       user: { connect: { id: userId } },
     });
     return {
+      ...defaultResponse,
       success: true,
-      data: todoFormData,
-      zodErrors: {},
-      prismaError: "",
     };
   } catch (error) {
     const detailedError = inspectPrismaError(error);
     console.error(detailedError);
     return {
-      success: false,
-      data: todoFormData,
-      zodErrors: {},
+      ...defaultResponse,
       prismaError: (error instanceof Error) ? error.name : `${error}`,
     };
   }

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -53,8 +53,8 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
       prismaError: "",
     };
   } catch (error) {
-    console.error(error);
     const detailedError = inspectPrismaError(error);
+    console.error(detailedError);
     return {
       success: false,
       data: todoFormData,

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,6 +1,6 @@
 import { Todo } from '@prisma/client';
 
-import { TodoSchema, TodoSchemaType, TodoFormState } from '@/models/todo';
+import { TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
 import { createTodo, findAllByUserId } from '@/repositories/todo_repository';
 import { inspectPrismaError } from '@/utils/prismaErrorUtils';
 

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -59,7 +59,7 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
       success: false,
       data: todoFormData,
       zodErrors: {},
-      prismaError: detailedError,
+      prismaError: (error instanceof Error) ? error.name : `${error}`,
     };
   }
 }

--- a/src/utils/prismaErrorUtils.ts
+++ b/src/utils/prismaErrorUtils.ts
@@ -7,6 +7,10 @@ export function inspectPrismaError(error: unknown): string {
     return `Unknown Request Error: ${error.name} - ${error.message}`;
   } else if (error instanceof Prisma.PrismaClientRustPanicError) {
     return `Rust Panic Error: ${error.name} - ${error.message}`;
+  } else if (error instanceof Prisma.PrismaClientInitializationError) {
+    return `Initialization Error: ${error.name} - ${error.message}`;
+  } else if (error instanceof Prisma.PrismaClientValidationError) {
+    return `Validation Error: ${error.name} - ${error.message}`;
   } else {
     return `Unknown error: ${error}`;
   }


### PR DESCRIPTION
Fixes #50

Refactor `createTodoAction` to move `todoFormData` creation, validation, and save logic to `todoService`.

* Move `todoFormData` creation and validation logic to `saveTodo` in `src/services/todoService.ts`.
* Update `saveTodo` to return validation errors and data of `todoFormData` if validation fails.
* Ensure the return value of `saveTodo` matches the updated `TodoFormState`.
* Remove `todoFormData` creation and validation logic from `createTodoAction` in `src/actions/todos.ts`.
* Call `saveTodo` and handle validation errors in `createTodoAction`.
* Update `type TodoFormState` to include boolean `success`, rename `errors` to `zodErrors`, and add `prismaError` as string in `src/models/todo.ts`.
* Update `TodoForm` for the updated `TodoFormState` and update error message logic accordingly in `src/components/TodoForm.tsx`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/51?shareId=b6437c09-c341-4cb4-80e6-be182d8ef9f2).