### PR TITLE
Add delete todo button

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 
 import { TodoFormState } from '@/models/todo';
-import { deleteTodo, saveTodo  } from '@/services/todoService';
+import { deleteTodo, saveTodo } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 
 export async function createTodoAction(prevState: TodoFormState, formData: FormData) {

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 
 import { TodoFormState } from '@/models/todo';
-import { saveTodo } from '@/services/todoService';
+import { saveTodo, deleteTodo } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 
 export async function createTodoAction(prevState: TodoFormState, formData: FormData) {
@@ -21,6 +21,18 @@ export async function createTodoAction(prevState: TodoFormState, formData: FormD
       ...result,
     };
   }
+
+  redirect('/');
+}
+
+export async function deleteTodoAction(todoId: number) {
+  const userId = await getCookie('user_id');
+
+  if (!userId) {
+    throw new Error('User ID not found in cookies');
+  }
+
+  await deleteTodo(todoId, Number(userId));
 
   redirect('/');
 }

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -3,7 +3,7 @@
 import { redirect } from 'next/navigation';
 
 import { TodoFormState } from '@/models/todo';
-import { saveTodo, deleteTodo } from '@/services/todoService';
+import { deleteTodo, saveTodo  } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 
 export async function createTodoAction(prevState: TodoFormState, formData: FormData) {

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,4 +1,5 @@
 import { Todo } from '@prisma/client';
+import { deleteTodoAction } from '@/actions/todos';
 
 type TodoListProps = {
   todos?: Todo[];
@@ -17,7 +18,15 @@ const TodoList = ({ todos, error }: TodoListProps) => {
   return (
     <ul className="list-disc pl-5">
       {todos.map((todo) => (
-        <li key={todo.id}>{todo.title}</li>
+        <li key={todo.id} className="flex items-center justify-between">
+          {todo.title}
+          <button 
+            onClick={() => deleteTodoAction(todo.id)} 
+            className="text-red-500 hover:text-red-700 ml-4"
+          >
+            &#x2716;
+          </button>
+        </li>
       ))}
     </ul>
   );

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,4 +1,5 @@
 import { Todo } from '@prisma/client';
+
 import { deleteTodoAction } from '@/actions/todos';
 
 type TodoListProps = {
@@ -15,17 +16,24 @@ const TodoList = ({ todos, error }: TodoListProps) => {
     return <div>No todos available</div>;
   }
 
+  const handleDelete = async (data : FormData) => {
+    'use server'
+    const todoId = data.get("todoId");
+    if (todoId)
+      await deleteTodoAction(Number(todoId))
+  }
+
   return (
     <ul className="list-disc pl-5">
       {todos.map((todo) => (
         <li key={todo.id} className="flex items-center justify-between">
           {todo.title}
-          <button 
-            onClick={() => deleteTodoAction(todo.id)} 
-            className="text-red-500 hover:text-red-700 ml-4"
-          >
-            &#x2716;
-          </button>
+          <form action={handleDelete}>
+            <input name="todoId" className="hidden" value={todo.id} readOnly/>
+            <button type="submit" className="text-red-500 hover:text-red-700 ml-4">
+              &#x2716;
+            </button>
+          </form>
         </li>
       ))}
     </ul>

--- a/src/repositories/todo_repository.ts
+++ b/src/repositories/todo_repository.ts
@@ -8,3 +8,7 @@ export async function createTodo(input: TodoCreateInput) {
 export async function findAllByUserId(userId: number) {
   return await prisma.todo.findMany({ where: { userId } });
 }
+
+export async function deleteTodoById(todoId: number, userId: number) {
+  return await prisma.todo.deleteMany({ where: { id: todoId, userId } });
+}

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,5 +1,5 @@
 import { TodoFetchResponse, TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
-import { createTodo, findAllByUserId } from '@/repositories/todo_repository';
+import { createTodo, findAllByUserId, deleteTodoById } from '@/repositories/todo_repository';
 import { inspectPrismaError } from '@/utils/prismaErrorUtils';
 
 export async function findAllTodos(userId: string | undefined): Promise<TodoFetchResponse> {
@@ -50,5 +50,15 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
     console.error(detailedError);
     const prismaError = (error instanceof Error) ? error.name : `${error}`;
     return { ...defaultResponse, prismaError };
+  }
+}
+
+export async function deleteTodo(todoId: number, userId: number): Promise<void> {
+  try {
+    await deleteTodoById(todoId, userId);
+  } catch (error) {
+    const detailedError = inspectPrismaError(error);
+    console.error(detailedError);
+    throw new Error((error instanceof Error) ? error.name : `${error}`);
   }
 }

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,5 +1,5 @@
 import { TodoFetchResponse, TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
-import { createTodo, findAllByUserId, deleteTodoById } from '@/repositories/todo_repository';
+import { createTodo, deleteTodoById, findAllByUserId } from '@/repositories/todo_repository';
 import { inspectPrismaError } from '@/utils/prismaErrorUtils';
 
 export async function findAllTodos(userId: string | undefined): Promise<TodoFetchResponse> {


### PR DESCRIPTION
Fixes #60

Add delete functionality for todos.

* **src/actions/todos.ts**
  - Add `deleteTodoAction` function to call `deleteTodo` from `todoService`.
  - Export `deleteTodoAction` function.

* **src/components/TodoList.tsx**
  - Add a delete button for each todo item.
  - Call `deleteTodoAction` on delete button click.
  - Style the delete button with a red color and a cross icon.

* **src/repositories/todo_repository.ts**
  - Add `deleteTodoById` function to delete a todo by its ID and userId.
  - Export `deleteTodoById` function.

* **src/services/todoService.ts**
  - Add `deleteTodo` function to call `deleteTodoById` from `todo_repository`.
  - Export `deleteTodo` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/61?shareId=521b050d-866e-4e8f-b20a-09ffce04badf).