### PR TITLE
Refactor deleteTodoAction to return DeleteTodoState

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation';
 
-import { TodoFormState } from '@/models/todo';
+import { DeleteTodoState, TodoFormState } from '@/models/todo';
 import { deleteTodo, saveTodo } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 
@@ -25,14 +25,18 @@ export async function createTodoAction(prevState: TodoFormState, formData: FormD
   redirect('/');
 }
 
-export async function deleteTodoAction(todoId: number) {
+export async function deleteTodoAction(todoId: number): Promise<DeleteTodoState> {
   const userId = await getCookie('user_id');
 
   if (!userId) {
     throw new Error('User ID not found in cookies');
   }
 
-  await deleteTodo(todoId, Number(userId));
+  const result = await deleteTodo(todoId, Number(userId));
+
+  if (!result.success) {
+    return result;
+  }
 
   redirect('/');
 }

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -19,8 +19,12 @@ const TodoList = ({ todos, error }: TodoListProps) => {
   const handleDelete = async (data : FormData) => {
     'use server'
     const todoId = data.get("todoId");
-    if (todoId)
-      await deleteTodoAction(Number(todoId))
+    if (todoId) {
+      const result = await deleteTodoAction(Number(todoId));
+      if (!result.success) {
+        console.error(result.prismaError);
+      }
+    }
   }
 
   return (

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -18,6 +18,11 @@ export type TodoFormState = {
   prismaError: string,
 };
 
+export type DeleteTodoState = {
+  success: boolean,
+  prismaError: string,
+};
+
 export type TodoCreateInput = Prisma.TodoCreateInput;
 
 export type TodoFetchResponse = {

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,4 +1,4 @@
-import { TodoFetchResponse, TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
+import { DeleteTodoState, TodoFetchResponse, TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
 import { createTodo, deleteTodoById, findAllByUserId } from '@/repositories/todo_repository';
 import { inspectPrismaError } from '@/utils/prismaErrorUtils';
 
@@ -53,12 +53,19 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
   }
 }
 
-export async function deleteTodo(todoId: number, userId: number): Promise<void> {
+export async function deleteTodo(todoId: number, userId: number): Promise<DeleteTodoState> {
+  const defaultResponse: DeleteTodoState = {
+    success: false,
+    prismaError: "",
+  };
+
   try {
     await deleteTodoById(todoId, userId);
+    return { ...defaultResponse, success: true };
   } catch (error) {
     const detailedError = inspectPrismaError(error);
     console.error(detailedError);
-    throw new Error((error instanceof Error) ? error.name : `${error}`);
+    const prismaError = (error instanceof Error) ? error.name : `${error}`;
+    return { ...defaultResponse, prismaError };
   }
 }


### PR DESCRIPTION
Fixes #62

Refactor `deleteTodoAction` and `deleteTodo` to return `DeleteTodoState`.

* Add `DeleteTodoState` type in `src/models/todo.ts` with `success: boolean` and `prismaError: string`.
* Modify `deleteTodo` in `src/services/todoService.ts` to return `DeleteTodoState` instead of void and handle errors without throwing.
* Modify `deleteTodoAction` in `src/actions/todos.ts` to return `DeleteTodoState` and handle the state similarly to `createTodoAction`.
* Update `handleDelete` in `src/components/TodoList.tsx` to handle the returned `DeleteTodoState` from `deleteTodoAction`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/issues/62?shareId=XXXX-XXXX-XXXX-XXXX).