### PR TITLE
TodoList error handling

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -25,17 +25,28 @@ export async function createTodoAction(prevState: TodoFormState, formData: FormD
   redirect('/');
 }
 
-export async function deleteTodoAction(todoId: number): Promise<DeleteTodoState> {
+export async function deleteTodoAction(prevState: DeleteTodoState, formData: FormData) {
   const userId = await getCookie('user_id');
 
   if (!userId) {
     throw new Error('User ID not found in cookies');
   }
 
-  const result = await deleteTodo(todoId, Number(userId));
+  const todoId = formData.get("todoId");
+  if (!todoId) {
+    return {
+      ...prevState,
+      prismaError: 'Todo ID not found in form data',
+    };
+  }
+
+  const result = await deleteTodo(Number(todoId), Number(userId));
 
   if (!result.success) {
-    return result;
+    return {
+      ...prevState,
+      ...result,
+    };
   }
 
   redirect('/');

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -35,7 +35,7 @@ const TodoList = ({ todos, error }: TodoListProps) => {
         <li key={todo.id} className="flex items-center justify-between">
           {todo.title}
           <form action={formAction}>
-            <input name="todoId" className="hidden" value={todo.id} readOnly/>
+            <input name="todoId" className="hidden" value={todo.id} readOnly />
             <button type="submit" className="text-red-500 hover:text-red-700 ml-4" disabled={pending}>
               &#x2716;
             </button>

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,30 +1,32 @@
+import { useActionState } from 'react';
 import { Todo } from '@prisma/client';
 
 import { deleteTodoAction } from '@/actions/todos';
+import { DeleteTodoState } from '@/models/todo';
 
 type TodoListProps = {
   todos?: Todo[];
   error?: string;
 }
 
+const initialState: DeleteTodoState = {
+  success: false,
+  prismaError: "",
+};
+
 const TodoList = ({ todos, error }: TodoListProps) => {
+  const [state, formAction, pending] = useActionState(deleteTodoAction, initialState);
+
   if (error) {
     return <div className="text-red-500">{error}</div>;
   }
 
-  if (!todos || todos.length === 0) {
-    return <div>No todos available</div>;
+  if (state.prismaError) {
+    return <div className="text-red-500">{state.prismaError}</div>;
   }
 
-  const handleDelete = async (data : FormData) => {
-    'use server'
-    const todoId = data.get("todoId");
-    if (todoId) {
-      const result = await deleteTodoAction(Number(todoId));
-      if (!result.success) {
-        console.error(result.prismaError);
-      }
-    }
+  if (!todos || todos.length === 0) {
+    return <div>No todos available</div>;
   }
 
   return (
@@ -32,9 +34,9 @@ const TodoList = ({ todos, error }: TodoListProps) => {
       {todos.map((todo) => (
         <li key={todo.id} className="flex items-center justify-between">
           {todo.title}
-          <form action={handleDelete}>
+          <form action={formAction}>
             <input name="todoId" className="hidden" value={todo.id} readOnly/>
-            <button type="submit" className="text-red-500 hover:text-red-700 ml-4">
+            <button type="submit" className="text-red-500 hover:text-red-700 ml-4" disabled={pending}>
               &#x2716;
             </button>
           </form>

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,5 +1,5 @@
-import { useActionState } from 'react';
 import { Todo } from '@prisma/client';
+import { useActionState } from 'react';
 
 import { deleteTodoAction } from '@/actions/todos';
 import { DeleteTodoState } from '@/models/todo';


### PR DESCRIPTION
Fixes #64

Update `TodoList` to handle errors similar to `TodoForm`.

* **`src/actions/todos.ts`**
  - Update `deleteTodoAction` to accept `FormData` argument.
  - Move logic from `handleDelete` in `TodoList` to `deleteTodoAction`.
  - Return `DeleteTodoState` when an error occurs instead of throwing an error.

* **`src/components/TodoList.tsx`**
  - Use `useActionState` to make the `state` available.
  - Display error using `state` on the screen.
  - Remove `handleDelete` function.
  - Disable delete button while the action is pending.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/65?shareId=c19f6132-5717-4255-93cd-9ba2446979e7).