### PR TITLE
Handle findAllTodos error in Home

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { toast } from 'react-hot-toast';
 
 import TodoList from '@/components/TodoList';
 import { findAllTodos } from '@/services/todoService';
@@ -10,16 +9,13 @@ export default async function Home() {
 
   const { todos, error } = await findAllTodos(userId);
 
-  if (error) {
-    toast.error(error);
-  }
-
   return (
     <div className="container">
       <main className="main">
         <h1>Todo App</h1>
         <p>User ID: {userId}</p>
-        <TodoList todos={todos} error={error} />
+        {error && <div className="text-red-500">{error}</div>}
+        <TodoList todos={todos} />
         <Link href="/create-todo">
           <button>Create Todo</button>
         </Link>

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -6,7 +6,6 @@ import { DeleteTodoState } from '@/models/todo';
 
 type TodoListProps = {
   todos?: Todo[];
-  error?: string;
 }
 
 const initialState: DeleteTodoState = {
@@ -14,12 +13,8 @@ const initialState: DeleteTodoState = {
   prismaError: "",
 };
 
-const TodoList = ({ todos, error }: TodoListProps) => {
+const TodoList = ({ todos }: TodoListProps) => {
   const [state, formAction, pending] = useActionState(deleteTodoAction, initialState);
-
-  if (error) {
-    return <div className="text-red-500">{error}</div>;
-  }
 
   if (state.prismaError) {
     return <div className="text-red-500">{state.prismaError}</div>;

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -12,10 +12,10 @@ export async function findAllTodos(userId: string | undefined): Promise<TodoFetc
     return { todos };
   } catch (error) {
     const detailedError = inspectPrismaError(error);
-    console.error(detailedError);
+    console.error("ERROR in findAllTodos: %s", detailedError);
+
     return {
-      error: (error instanceof Error) ? error.name : `${error}`,
-    };
+ error: (error instanceof Error) ? error.name : `${error}` };
   }
 }
 

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -14,8 +14,7 @@ export async function findAllTodos(userId: string | undefined): Promise<TodoFetc
     const detailedError = inspectPrismaError(error);
     console.error("ERROR in findAllTodos: %s", detailedError);
 
-    return {
- error: (error instanceof Error) ? error.name : `${error}` };
+    return { error: (error instanceof Error) ? error.name : `${error}` };
   }
 }
 


### PR DESCRIPTION
Fixes #66

Improve error handling in `src/app/page.tsx` and `src/components/TodoList.tsx`.

* Remove `toast.error` and its import from `src/app/page.tsx`.
* Remove `error` prop from `TodoList` in `src/app/page.tsx`.
* Add `{error && <div className="text-red-500">{error}</div>}` to display error directly in `src/app/page.tsx`.
* Remove `error` from `TodoListProps` in `src/components/TodoList.tsx`.
* Remove `if (error)` return div part in `src/components/TodoList.tsx`.
* Update `console.error` in `findAllTodos` in `src/services/todoService.ts` to `console.error("ERROR in findAllTodos: %s", detailedError);`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/67?shareId=1f3161cd-40ad-477f-af18-d1fb191ab162).