### PR TITLE
Quick fix DeleteTodoButton

### DIFF
--- a/src/components/DeleteTodoButton.tsx
+++ b/src/components/DeleteTodoButton.tsx
@@ -17,10 +17,6 @@ type DeleteTodoButtonProps = {
 const DeleteTodoButton = ({ todoId }: DeleteTodoButtonProps) => {
   const [state, formAction, pending] = useActionState(deleteTodoAction, initialState);
 
-  if (state.prismaError) {
-    return <div className="text-red-500">{state.prismaError}</div>;
-  }
-
   return (
     <form action={formAction}>
       <input name="todoId" className="hidden" value={todoId} readOnly />


### PR DESCRIPTION
Fixes #70

Remove the 'if (state.prismaError)' block from the `DeleteTodoButton` component.

* Ensure the error message is shown only once below the form in the `DeleteTodoButton` component.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/71?shareId=e417d4cd-1e6c-4e08-b2d2-252ae1e4cb53).