### PR TITLE
Update todo actions to return without prevState

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -16,10 +16,7 @@ export async function createTodoAction(prevState: TodoFormState, formData: FormD
   const result = await saveTodo(formData, Number(userId));
 
   if (!result.success) {
-    return {
-      ...prevState,
-      ...result,
-    };
+    return result;
   }
 
   redirect('/');
@@ -33,20 +30,15 @@ export async function deleteTodoAction(prevState: DeleteTodoState, formData: For
   }
 
   const todoId = formData.get("todoId");
+
   if (!todoId) {
-    return {
-      ...prevState,
-      prismaError: 'Todo ID not found in form data',
-    };
+    return { success: false, prismaError: 'Todo ID not found in form data' };
   }
 
   const result = await deleteTodo(Number(todoId), Number(userId));
 
   if (!result.success) {
-    return {
-      ...prevState,
-      ...result,
-    };
+    return result;
   }
 
   redirect('/');


### PR DESCRIPTION
Fixes #72

Update `createTodoAction` and `deleteTodoAction` in `src/actions/todos.ts` to return without using `prevState`.

* Modify `createTodoAction` to return an object with `success`, `data`, `zodErrors`, and `prismaError` directly.
* Modify `deleteTodoAction` to return an object with `success` and `prismaError` directly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/73?shareId=07355db8-388a-4f55-a062-ebb7f9f4b73c).