### PR TITLE
Rename variables

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -32,7 +32,7 @@ export async function deleteTodoAction(prevState: DeleteTodoState, formData: For
   const todoId = formData.get("todoId");
 
   if (!todoId) {
-    return { success: false, prismaError: 'Todo ID not found in form data' };
+    return { success: false, message: 'Todo ID not found in form data' };
   }
 
   const result = await deleteTodo(Number(todoId), Number(userId));

--- a/src/components/DeleteTodoButton.tsx
+++ b/src/components/DeleteTodoButton.tsx
@@ -7,7 +7,7 @@ import { DeleteTodoState } from '@/models/todo';
 
 const initialState: DeleteTodoState = {
   success: false,
-  prismaError: "",
+  message: "",
 };
 
 type DeleteTodoButtonProps = {
@@ -23,7 +23,7 @@ const DeleteTodoButton = ({ todoId }: DeleteTodoButtonProps) => {
       <button type="submit" className="text-red-500 hover:text-red-700 ml-4" disabled={pending}>
         &#x2716;
       </button>
-      {state.prismaError && <p className="text-red-500">{state.prismaError}</p>}
+      {state.message && <p className="text-red-500">{state.message}</p>}
     </form>
   )
 };

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -11,7 +11,7 @@ const initialState: TodoFormState = {
   success: false,
   data: { title: "", completed: false },
   zodErrors: {},
-  prismaError: "",
+  message: "",
 };
 
 const TodoForm = () => {
@@ -33,7 +33,7 @@ const TodoForm = () => {
           <input type="checkbox" id="completed" name="completed" className="checkbox" defaultChecked={completed} />
         </label>
       </div>
-      {state.prismaError && <p className="text-red-500">{state.prismaError}</p>}
+      {state.message && <p className="text-red-500">{state.message}</p>}
       <button type="submit" className={styles.button} disabled={pending}>Create Todo</button>
     </form>
   );

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -15,12 +15,12 @@ export type TodoFormState = {
   success: boolean,
   data: TodoSchemaType,
   zodErrors: TodoFieldErrors,
-  prismaError: string,
+  message: string,
 };
 
 export type DeleteTodoState = {
   success: boolean,
-  prismaError: string,
+  message: string,
 };
 
 export type TodoCreateInput = Prisma.TodoCreateInput;

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -47,6 +47,7 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
   } catch (e) {
     const error = inspectPrismaError(e);
     console.error(error);
+
     const message = (e instanceof Error) ? e.name : `${e}`;
     return { ...res, message };
   }
@@ -64,6 +65,7 @@ export async function deleteTodo(todoId: number, userId: number): Promise<Delete
   } catch (e) {
     const error = inspectPrismaError(e);
     console.error(error);
+
     const message = (e instanceof Error) ? e.name : `${e}`;
     return { ...res, message };
   }

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -10,11 +10,11 @@ export async function findAllTodos(userId: string | undefined): Promise<TodoFetc
   try {
     const todos = await findAllByUserId(Number(userId));
     return { todos };
-  } catch (error) {
-    const detailedError = inspectPrismaError(error);
+  } catch (e) {
+    const detailedError = inspectPrismaError(e);
     console.error("ERROR in findAllTodos: %s", detailedError);
 
-    return { error: (error instanceof Error) ? error.name : `${error}` };
+    return { error: (e instanceof Error) ? e.name : `${e}` };
   }
 }
 
@@ -24,47 +24,47 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
     completed: formData.get('completed') === 'on',  // checkbox value is on/off
   };
 
-  const validatedFields = TodoSchema.safeParse(todoFormData);
+  const result = TodoSchema.safeParse(todoFormData);
 
-  const defaultResponse: TodoFormState = {
+  const res: TodoFormState = {
     success: false,
     data: todoFormData,
     zodErrors: {},
     prismaError: "",
   };
 
-  if (!validatedFields.success) {
-    const zodErrors = validatedFields.error.flatten().fieldErrors;
-    return { ...defaultResponse, zodErrors };
+  if (!result.success) {
+    const zodErrors = result.error.flatten().fieldErrors;
+    return { ...res, zodErrors };
   }
 
   try {
     await createTodo({
-      ...validatedFields.data,
+      ...result.data,
       user: { connect: { id: userId } },
     });
-    return { ...defaultResponse, success: true };
-  } catch (error) {
-    const detailedError = inspectPrismaError(error);
+    return { ...res, success: true };
+  } catch (e) {
+    const detailedError = inspectPrismaError(e);
     console.error(detailedError);
-    const prismaError = (error instanceof Error) ? error.name : `${error}`;
-    return { ...defaultResponse, prismaError };
+    const prismaError = (e instanceof Error) ? e.name : `${e}`;
+    return { ...res, prismaError };
   }
 }
 
 export async function deleteTodo(todoId: number, userId: number): Promise<DeleteTodoState> {
-  const defaultResponse: DeleteTodoState = {
+  const res: DeleteTodoState = {
     success: false,
     prismaError: "",
   };
 
   try {
     await deleteTodoById(todoId, userId);
-    return { ...defaultResponse, success: true };
-  } catch (error) {
-    const detailedError = inspectPrismaError(error);
+    return { ...res, success: true };
+  } catch (e) {
+    const detailedError = inspectPrismaError(e);
     console.error(detailedError);
-    const prismaError = (error instanceof Error) ? error.name : `${error}`;
-    return { ...defaultResponse, prismaError };
+    const prismaError = (e instanceof Error) ? e.name : `${e}`;
+    return { ...res, prismaError };
   }
 }

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -30,7 +30,7 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
     success: false,
     data: todoFormData,
     zodErrors: {},
-    prismaError: "",
+    message: "",
   };
 
   if (!result.success) {
@@ -47,15 +47,15 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
   } catch (e) {
     const detailedError = inspectPrismaError(e);
     console.error(detailedError);
-    const prismaError = (e instanceof Error) ? e.name : `${e}`;
-    return { ...res, prismaError };
+    const message = (e instanceof Error) ? e.name : `${e}`;
+    return { ...res, message };
   }
 }
 
 export async function deleteTodo(todoId: number, userId: number): Promise<DeleteTodoState> {
   const res: DeleteTodoState = {
     success: false,
-    prismaError: "",
+    message: "",
   };
 
   try {
@@ -64,7 +64,7 @@ export async function deleteTodo(todoId: number, userId: number): Promise<Delete
   } catch (e) {
     const detailedError = inspectPrismaError(e);
     console.error(detailedError);
-    const prismaError = (e instanceof Error) ? e.name : `${e}`;
-    return { ...res, prismaError };
+    const message = (e instanceof Error) ? e.name : `${e}`;
+    return { ...res, message };
   }
 }

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -11,8 +11,8 @@ export async function findAllTodos(userId: string | undefined): Promise<TodoFetc
     const todos = await findAllByUserId(Number(userId));
     return { todos };
   } catch (e) {
-    const detailedError = inspectPrismaError(e);
-    console.error("ERROR in findAllTodos: %s", detailedError);
+    const error = inspectPrismaError(e);
+    console.error("ERROR in findAllTodos: %s", error);
 
     return { error: (e instanceof Error) ? e.name : `${e}` };
   }
@@ -45,8 +45,8 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
     });
     return { ...res, success: true };
   } catch (e) {
-    const detailedError = inspectPrismaError(e);
-    console.error(detailedError);
+    const error = inspectPrismaError(e);
+    console.error(error);
     const message = (e instanceof Error) ? e.name : `${e}`;
     return { ...res, message };
   }
@@ -62,8 +62,8 @@ export async function deleteTodo(todoId: number, userId: number): Promise<Delete
     await deleteTodoById(todoId, userId);
     return { ...res, success: true };
   } catch (e) {
-    const detailedError = inspectPrismaError(e);
-    console.error(detailedError);
+    const error = inspectPrismaError(e);
+    console.error(error);
     const message = (e instanceof Error) ? e.name : `${e}`;
     return { ...res, message };
   }


### PR DESCRIPTION
Fixes #74

Rename variables in `src/services/todoService.ts` to improve code readability.

* Rename `validatedFields` to `result`
* Rename `defaultResponse` to `res`
* Rename `catch (error)` to `catch (e)`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/75?shareId=90c7ccee-9f84-49d8-be9a-6cab66118129).