### PR TITLE
Rename zodErrors to errors

### DIFF
--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -9,9 +9,9 @@ import styles from './TodoForm.module.css';
 
 const initialState: TodoFormState = {
   success: false,
-  data: { title: "", completed: false },
-  zodErrors: {},
   message: "",
+  data: { title: "", completed: false },
+  errors: {},
 };
 
 const TodoForm = () => {
@@ -25,7 +25,7 @@ const TodoForm = () => {
           <span className="label-text">Title:</span>
         </label>
         <input type="text" id="title" name="title" className="input input-bordered" required defaultValue={title} />
-        {state.zodErrors?.title && <p className="text-red-500">{state.zodErrors.title}</p>}
+        {state.errors?.title && <p className="text-red-500">{state.errors.title}</p>}
       </div>
       <div className="form-control">
         <label htmlFor="completed" className="label cursor-pointer">

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -13,9 +13,9 @@ type TodoFieldErrors = z.inferFlattenedErrors<typeof TodoSchema>['fieldErrors'];
 
 export type TodoFormState = {
   success: boolean,
-  data: TodoSchemaType,
-  zodErrors: TodoFieldErrors,
   message: string,
+  data: TodoSchemaType,
+  errors: TodoFieldErrors,
 };
 
 export type DeleteTodoState = {

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -28,14 +28,14 @@ export async function saveTodo(formData: FormData, userId: number): Promise<Todo
 
   const res: TodoFormState = {
     success: false,
-    data: todoFormData,
-    zodErrors: {},
     message: "",
+    data: todoFormData,
+    errors: {},
   };
 
   if (!result.success) {
-    const zodErrors = result.error.flatten().fieldErrors;
-    return { ...res, zodErrors };
+    const errors = result.error.flatten().fieldErrors;
+    return { ...res, errors };
   }
 
   try {


### PR DESCRIPTION
Fixes #76

Rename `zodErrors` to `errors` and change the order of `message: string` in `TodoFormState`.

* **src/components/TodoForm.tsx**
  - Rename `zodErrors` to `errors` in the `initialState` object.
  - Rename `state.zodErrors` to `state.errors` in the `TodoForm` component.

* **src/models/todo.ts**
  - Change the order of `message: string` to be the second element in the `TodoFormState` type.
  - Rename `zodErrors` to `errors` in the `TodoFormState` type.

* **src/services/todoService.ts**
  - Rename `zodErrors` to `errors` in the `saveTodo` function.
  - Change the order of `message: string` to be the second element in the `res` object in the `saveTodo` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/77?shareId=0a657dfa-d337-4259-a556-9c8414bbba68).