### PR TITLE
Refactor deleteTodoAction to handle delete operation without form

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -22,20 +22,14 @@ export async function createTodoAction(prevState: TodoFormState, formData: FormD
   redirect('/');
 }
 
-export async function deleteTodoAction(prevState: DeleteTodoState, formData: FormData) {
+export async function deleteTodoAction(todoId: number) {
   const userId = await getCookie('user_id');
 
   if (!userId) {
     throw new Error('User ID not found in cookies');
   }
 
-  const todoId = formData.get("todoId");
-
-  if (!todoId) {
-    return { success: false, message: 'Todo ID not found in form data' };
-  }
-
-  const result = await deleteTodo(Number(todoId), Number(userId));
+  const result = await deleteTodo(todoId, Number(userId));
 
   if (!result.success) {
     return result;

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -2,7 +2,7 @@
 
 import { redirect } from 'next/navigation';
 
-import { DeleteTodoState, TodoFormState } from '@/models/todo';
+import { TodoFormState } from '@/models/todo';
 import { deleteTodo, saveTodo } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 

--- a/src/components/DeleteTodoButton.tsx
+++ b/src/components/DeleteTodoButton.tsx
@@ -20,7 +20,7 @@ const DeleteTodoButton = ({ todoId }: DeleteTodoButtonProps) => {
   const { pending } = useFormStatus();
 
   const handleDelete = async () => {
-    const result = await deleteTodoAction(state, todoId);
+    const result = await deleteTodoAction(todoId);
     setState(result);
   };
 

--- a/src/components/DeleteTodoButton.tsx
+++ b/src/components/DeleteTodoButton.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { useActionState } from 'react';
-
 import { deleteTodoAction } from '@/actions/todos';
 
 type DeleteTodoButtonProps = {

--- a/src/components/DeleteTodoButton.tsx
+++ b/src/components/DeleteTodoButton.tsx
@@ -3,20 +3,12 @@
 import { useActionState } from 'react';
 
 import { deleteTodoAction } from '@/actions/todos';
-import { DeleteTodoState } from '@/models/todo';
-
-const initialState: DeleteTodoState = {
-  success: false,
-  message: "",
-};
 
 type DeleteTodoButtonProps = {
   todoId: number;
 }
 
 const DeleteTodoButton = ({ todoId }: DeleteTodoButtonProps) => {
-  const [state, formAction, pending] = useActionState(deleteTodoAction, initialState);
-
   const handleClick = async () => {
     await deleteTodoAction(todoId);
   };

--- a/src/components/DeleteTodoButton.tsx
+++ b/src/components/DeleteTodoButton.tsx
@@ -1,19 +1,32 @@
 'use client'
 
+import { useState } from 'react';
+import { useFormStatus } from 'react-dom';
+
 import { deleteTodoAction } from '@/actions/todos';
+import { DeleteTodoState } from '@/models/todo';
+
+const initialState: DeleteTodoState = {
+  success: false,
+  message: "",
+};
 
 type DeleteTodoButtonProps = {
   todoId: number;
 }
 
 const DeleteTodoButton = ({ todoId }: DeleteTodoButtonProps) => {
-  const handleClick = async () => {
-    await deleteTodoAction(todoId);
+  const [state, setState] = useState<DeleteTodoState>(initialState);
+  const { pending } = useFormStatus();
+
+  const handleDelete = async () => {
+    const result = await deleteTodoAction(state, todoId);
+    setState(result);
   };
 
   return (
     <>
-      <button onClick={handleClick} className="text-red-500 hover:text-red-700 ml-4" disabled={pending}>
+      <button onClick={handleDelete} className="text-red-500 hover:text-red-700 ml-4" disabled={pending}>
         &#x2716;
       </button>
       {state.message && <p className="text-red-500">{state.message}</p>}

--- a/src/components/DeleteTodoButton.tsx
+++ b/src/components/DeleteTodoButton.tsx
@@ -17,14 +17,17 @@ type DeleteTodoButtonProps = {
 const DeleteTodoButton = ({ todoId }: DeleteTodoButtonProps) => {
   const [state, formAction, pending] = useActionState(deleteTodoAction, initialState);
 
+  const handleClick = async () => {
+    await deleteTodoAction(todoId);
+  };
+
   return (
-    <form action={formAction}>
-      <input name="todoId" className="hidden" value={todoId} readOnly />
-      <button type="submit" className="text-red-500 hover:text-red-700 ml-4" disabled={pending}>
+    <>
+      <button onClick={handleClick} className="text-red-500 hover:text-red-700 ml-4" disabled={pending}>
         &#x2716;
       </button>
       {state.message && <p className="text-red-500">{state.message}</p>}
-    </form>
+    </>
   )
 };
 


### PR DESCRIPTION
Fixes #78

Refactor `deleteTodoAction` to handle delete operation without form.

* Refactor `deleteTodoAction` in `src/actions/todos.ts` to accept `todoId` as an argument directly.
* Remove form data handling from `deleteTodoAction`.
* Refactor `DeleteTodoButton` in `src/components/DeleteTodoButton.tsx` to call `deleteTodoAction` directly with `todoId`.
* Remove form and formAction from `DeleteTodoButton`.
* Update button onClick event to call `deleteTodoAction` with `todoId`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/79?shareId=a96195ad-90a1-4c88-a0cb-c3ddb91d9297).