### PR TITLE
Fix deleteTodoAction and DeleteTodoButton

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { TodoFormState } from '@/models/todo';
@@ -35,5 +36,5 @@ export async function deleteTodoAction(todoId: number) {
     return result;
   }
 
-  redirect('/');
+  revalidatePath('/');
 }

--- a/src/components/DeleteTodoButton.tsx
+++ b/src/components/DeleteTodoButton.tsx
@@ -6,17 +6,12 @@ import { useFormStatus } from 'react-dom';
 import { deleteTodoAction } from '@/actions/todos';
 import { DeleteTodoState } from '@/models/todo';
 
-const initialState: DeleteTodoState = {
-  success: false,
-  message: "",
-};
-
 type DeleteTodoButtonProps = {
   todoId: number;
 }
 
 const DeleteTodoButton = ({ todoId }: DeleteTodoButtonProps) => {
-  const [state, setState] = useState<DeleteTodoState>(initialState);
+  const [state, setState] = useState<DeleteTodoState>();
   const { pending } = useFormStatus();
 
   const handleDelete = async () => {
@@ -29,7 +24,7 @@ const DeleteTodoButton = ({ todoId }: DeleteTodoButtonProps) => {
       <button onClick={handleDelete} className="text-red-500 hover:text-red-700 ml-4" disabled={pending}>
         &#x2716;
       </button>
-      {state.message && <p className="text-red-500">{state.message}</p>}
+      {state?.message && <p className="text-red-500">{state.message}</p>}
     </>
   )
 };


### PR DESCRIPTION
Fixes #80

Update `deleteTodoAction` and `DeleteTodoButton` to improve functionality.

* **`src/actions/todos.ts`**
  - Import `revalidatePath` from `'next/cache'`.
  - Replace `redirect('/')` with `revalidatePath('/')` in `deleteTodoAction`.

* **`src/components/DeleteTodoButton.tsx`**
  - Remove `initialState`.
  - Update `useState` to `useState<DeleteTodoState | undefined>(undefined)`.
  - Replace `state.message` with `state?.message`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/81?shareId=d2253e9c-7dca-4bdc-85d9-34a8c68909bd).