### PR TITLE
Introduce generics state type

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { TodoFormState } from '@/models/todo';
+import { TodoFormState, FuncState } from '@/models/todo';
 import { deleteTodo, saveTodo } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { TodoFormState, FuncState } from '@/models/todo';
+import { TodoFormState, DeleteTodoState } from '@/models/todo';
 import { deleteTodo, saveTodo } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 
@@ -23,7 +23,7 @@ export async function createTodoAction(prevState: TodoFormState, formData: FormD
   redirect('/');
 }
 
-export async function deleteTodoAction(todoId: number) {
+export async function deleteTodoAction(todoId: number): Promise<DeleteTodoState> {
   const userId = await getCookie('user_id');
 
   if (!userId) {
@@ -37,4 +37,5 @@ export async function deleteTodoAction(todoId: number) {
   }
 
   revalidatePath('/');
+  return result;
 }

--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
-import { TodoFormState, DeleteTodoState } from '@/models/todo';
+import { DeleteTodoState, TodoFormState } from '@/models/todo';
 import { deleteTodo, saveTodo } from '@/services/todoService';
 import { getCookie } from '@/utils/cookieUtils';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,14 +7,14 @@ import { getCookie } from '@/utils/cookieUtils';
 export default async function Home() {
   const userId = await getCookie('user_id');
 
-  const { todos, error } = await findAllTodos(userId);
+  const { data: todos, message } = await findAllTodos(userId);
 
   return (
     <div className="container">
       <main className="main">
         <h1>Todo App</h1>
         <p>User ID: {userId}</p>
-        {error && <div className="text-red-500">{error}</div>}
+        {message && <div className="text-red-500">{message}</div>}
         <TodoList todos={todos} />
         <Link href="/create-todo">
           <button>Create Todo</button>

--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -11,19 +11,21 @@ export type TodoSchemaType = z.infer<typeof TodoSchema>;
 // use only fieldErrors and skip not so useful formErrors
 type TodoFieldErrors = z.inferFlattenedErrors<typeof TodoSchema>['fieldErrors'];
 
-export type TodoFormState = {
+export type FormState<FORMDATA, ERRORS> = {
   success: boolean,
   message: string,
-  data: TodoSchemaType,
-  errors: TodoFieldErrors,
+  data: FORMDATA,
+  errors: ERRORS,
 };
 
-export type DeleteTodoState = {
+export type TodoFormState = FormState<TodoSchemaType, TodoFieldErrors>;
+
+export type FuncState<T> = {
   success: boolean,
-  message: string,
+  message?: string,
+  data?: T,
 };
 
-export type TodoFetchResponse = {
-  todos?: Todo[];
-  error?: string;
-}
+export type DeleteTodoState = FuncState<Todo>;
+
+export type TodoFetchResponse = FuncState<Todo[]>;

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -4,17 +4,17 @@ import { inspectPrismaError } from '@/utils/prismaErrorUtils';
 
 export async function findAllTodos(userId: string | undefined): Promise<TodoFetchResponse> {
   if (!userId) {
-    return { todos: [] };
+    return { success: true, data: [] };
   }
 
   try {
     const todos = await findAllByUserId(Number(userId));
-    return { todos };
+    return { success: true, data: todos };
   } catch (e) {
     const error = inspectPrismaError(e);
     console.error("ERROR in findAllTodos: %s", error);
 
-    return { error: (e instanceof Error) ? e.name : `${e}` };
+    return { success: false, message: (e instanceof Error) ? e.name : `${e}` };
   }
 }
 


### PR DESCRIPTION
Fixes #84

Update types in `src/models/todo.ts` to use generics for `TodoFormState`, `FormState`, and `FuncState`.

* Define `FormState<FORMDATA, ERRORS>` as a generic type with `success`, `message`, `data`, and `errors` properties.
* Create `TodoFormState` from the generic `FormState` with specific `TodoSchemaType` and `TodoFieldErrors`.
* Define `FuncState<T>` as a generic type with `success`, `message`, and `data` properties.
* Merge `DeleteTodoState` and `TodoFetchResponse` into the generic `FuncState<T>`.

Update `src/actions/todos.ts` to use the generic `FormState` and `FuncState`.

Update `src/services/todoService.ts` to use the generic `FuncState` for `findAllTodos` and `saveTodo`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/85?shareId=7e5028d4-4ecf-49a3-b3fe-2ba89a11e42e).