### PR TITLE
Fix deleteTodoAction SonarQube issue

### DIFF
--- a/src/actions/todos.ts
+++ b/src/actions/todos.ts
@@ -19,10 +19,9 @@ export async function createTodoAction(prevState: TodoFormState, formData: FormD
 export async function deleteTodoAction(todoId: number): Promise<DeleteTodoState> {
   const result = await deleteTodo(todoId);
 
-  if (result.error) {
-    return result;
+  if (!result.error) {
+    revalidatePath('/');
   }
 
-  revalidatePath('/');
   return result;
 }


### PR DESCRIPTION
Fixes #90

Refactor the `deleteTodoAction` function to use a single return statement.

* Remove the redundant `revalidatePath('/')` call.
* Move the `revalidatePath('/')` call inside the `if` block checking for `result.error`.
* Return the `result` variable directly at the end of the function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/91?shareId=f37844dd-ac57-4dc7-806e-e4a83400616f).