### PR TITLE
Refactor todoService.ts to make the return error DRY

### DIFF
--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,7 +1,7 @@
 import { DeleteTodoState, TodoFetchResponse, TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
 import { createTodo, deleteTodoById, findAllByUserId } from '@/repositories/todo_repository';
 import { getUserId } from '@/utils/cookieUtils';
-import { inspectPrismaError } from '@/utils/prismaErrorUtils';
+import { errorName, inspectPrismaError } from '@/utils/errorUtils';
 
 export async function findAllTodos(): Promise<TodoFetchResponse> {
   try {
@@ -12,7 +12,7 @@ export async function findAllTodos(): Promise<TodoFetchResponse> {
     const errorDetails = inspectPrismaError(e);
     console.error("ERROR in findAllTodos: %s", errorDetails);
 
-    return { error: (e instanceof Error) ? e.name : `${e}` };
+    return { error: errorName(e) };
   }
 }
 
@@ -36,7 +36,7 @@ export async function saveTodo(formData: FormData): Promise<TodoFormState> {
     const errorDetails = inspectPrismaError(e);
     console.error(errorDetails);
 
-    return { data, error: (e instanceof Error) ? e.name : `${e}` };
+    return { data, error: errorName(e) };
   }
 }
 
@@ -49,6 +49,6 @@ export async function deleteTodo(todoId: number): Promise<DeleteTodoState> {
     const errorDetails = inspectPrismaError(e);
     console.error(errorDetails);
 
-    return { error: (e instanceof Error) ? e.name : `${e}` };
+    return { error: errorName(e) };
   }
 }

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -1,5 +1,9 @@
 import { Prisma } from '@prisma/client';
 
+export function errorName(e: unknown): string {
+  return (e instanceof Error) ? e.name : `${e}`;
+}
+
 export function inspectPrismaError(error: unknown): string {
   if (error instanceof Prisma.PrismaClientKnownRequestError) {
     return `Known Request Error: ${error.code} - ${error.name} - ${error.message}`;


### PR DESCRIPTION
Fixes #92

Refactor error handling in `todoService.ts` to make it DRY.

* Create a new utility function `errorName` in `src/utils/errorUtils.ts` to handle error logic.
* Move `inspectPrismaError` function from `src/utils/prismaErrorUtils.ts` to `src/utils/errorUtils.ts`.
* Replace repeated error handling logic with `errorName` in `findAllTodos`, `saveTodo`, and `deleteTodo` functions in `src/services/todoService.ts`.
* Delete `src/utils/prismaErrorUtils.ts` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/93?shareId=d15132d3-e401-4048-ad66-9e831bb7de34).