### PR TITLE
Refactor todoService.ts to make inspectPrismaError DRY

### DIFF
--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,7 +1,7 @@
 import { DeleteTodoState, TodoFetchResponse, TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
 import { createTodo, deleteTodoById, findAllByUserId } from '@/repositories/todo_repository';
 import { getUserId } from '@/utils/cookieUtils';
-import { errorName, inspectPrismaError } from '@/utils/errorUtils';
+import { errorName, logPrismaError } from '@/utils/errorUtils';
 
 export async function findAllTodos(): Promise<TodoFetchResponse> {
   try {
@@ -9,9 +9,7 @@ export async function findAllTodos(): Promise<TodoFetchResponse> {
     const todos = await findAllByUserId(userId);
     return { data: todos };
   } catch (e) {
-    const errorDetails = inspectPrismaError(e);
-    console.error("ERROR in findAllTodos: %s", errorDetails);
-
+    logPrismaError(e, "findAllTodos");
     return { error: errorName(e) };
   }
 }
@@ -33,9 +31,7 @@ export async function saveTodo(formData: FormData): Promise<TodoFormState> {
     await createTodo({ ...result.data, user: { connect: { id: userId } } });
     return { data };
   } catch (e) {
-    const errorDetails = inspectPrismaError(e);
-    console.error(errorDetails);
-
+    logPrismaError(e, "saveTodo");
     return { data, error: errorName(e) };
   }
 }
@@ -46,9 +42,7 @@ export async function deleteTodo(todoId: number): Promise<DeleteTodoState> {
     const todo = await deleteTodoById(todoId, userId);
     return { data: todo };
   } catch (e) {
-    const errorDetails = inspectPrismaError(e);
-    console.error(errorDetails);
-
+    logPrismaError(e, "deleteTodo");
     return { error: errorName(e) };
   }
 }

--- a/src/utils/errorUtils.ts
+++ b/src/utils/errorUtils.ts
@@ -19,3 +19,8 @@ export function inspectPrismaError(error: unknown): string {
     return `Unknown error: ${error}`;
   }
 }
+
+export function logPrismaError(error: unknown, context: string): void {
+  const errorDetails = inspectPrismaError(error);
+  console.error(`ERROR in ${context}: ${errorDetails}`);
+}


### PR DESCRIPTION
Fixes #94

Refactor error handling in `todoService.ts` to make it DRY.

* Add a new function `logPrismaError` in `src/utils/errorUtils.ts` that combines `inspectPrismaError` and `console.error`.
* Replace `inspectPrismaError` and `console.error` calls in `findAllTodos`, `saveTodo`, and `deleteTodo` functions in `src/services/todoService.ts` with `logPrismaError`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/95?shareId=c95ca371-020a-4928-9aa7-c82b93c32ff8).