### PR TITLE
Sort order of todo list

### DIFF
--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -23,6 +23,7 @@ const TodoList = ({ todos }: TodoListProps) => {
               readOnly
             />
             <span className="ml-2">{todo.title}</span>
+            <span className="ml-2 text-xs text-gray-500">{new Date(todo.createdAt).toLocaleString()}</span>
           </div>
           <DeleteTodoButton todoId={todo.id} />
         </li>

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -23,9 +23,11 @@ const TodoList = ({ todos }: TodoListProps) => {
               readOnly
             />
             <span className="ml-2">{todo.title}</span>
-            <span className="ml-2 text-xs text-gray-500">{new Date(todo.createdAt).toLocaleString()}</span>
           </div>
-          <DeleteTodoButton todoId={todo.id} />
+          <div className="flex items-center">
+            <span className="ml-2 text-xs text-gray-500">{new Date(todo.createdAt).toISOString().replace('T', ' ').substring(0,19)}</span>
+            <DeleteTodoButton todoId={todo.id} />
+          </div>
         </li>
       ))}
     </ul>

--- a/src/repositories/todo_repository.ts
+++ b/src/repositories/todo_repository.ts
@@ -6,8 +6,8 @@ export async function createTodo(input: Prisma.TodoCreateInput): Promise<Todo> {
   return await prisma.todo.create({ data: { ...input } });
 }
 
-export async function findAllByUserId(userId: number): Promise<Todo[]> {
-  return await prisma.todo.findMany({ where: { userId } });
+export async function findAllByUserId(userId: number, orderBy: keyof Todo = 'createdAt'): Promise<Todo[]> {
+  return await prisma.todo.findMany({ where: { userId }, orderBy: { [orderBy]: 'asc' } });
 }
 
 export async function deleteTodoById(todoId: number, userId: number): Promise<Todo> {


### PR DESCRIPTION
Fixes #100

Update the order of todos in the `TodoList` component to be sorted by `createdAt` by default and display the `createdAt` timestamp.

* **src/repositories/todo_repository.ts**
  - Add an argument `orderBy` to the `findAllByUserId` function with a default value of `createdAt`.
  - Update the `findAllByUserId` function to use the `orderBy` argument for sorting.

* **src/components/TodoList.tsx**
  - Display the `createdAt` timestamp in the `TodoList` component.
  - Use a compact design with small letters for the `createdAt` timestamp.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/101?shareId=45bea007-14c7-45f6-914c-0edff98be61c).