### PR TITLE
Fix error: PrismaClient is not configured to run in Edge Runtime

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,0 +1,7 @@
+import type { NextAuthConfig } from "next-auth"
+import GitHub from "next-auth/providers/github"
+
+// Notice this is only an object, not a full Auth.js instance
+export default {
+  providers: [GitHub],
+} satisfies NextAuthConfig

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -18,7 +18,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
       return token
     },
     session({ session, token }) {
-      session.user.id = token.id
+      session.user.id = token.id as string
       return session
     },
   },

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,10 +1,25 @@
 import { PrismaAdapter } from "@auth/prisma-adapter"
 import NextAuth from "next-auth"
-import GitHub from "next-auth/providers/github"
 
+import authConfig from "@/auth.config"
 import { prisma } from "@/lib/prisma"
 
-export const { handlers, signIn, signOut, auth } = NextAuth({
+export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(prisma),
-  providers: [GitHub],
+  // https://authjs.dev/guides/edge-compatibility
+  session: { strategy: "jwt" },
+  ...authConfig,
+  // https://authjs.dev/guides/extending-the-session
+  callbacks: {
+    jwt({ token, user }) {
+      if (user) { // User is available during sign-in
+        token.id = user.id
+      }
+      return token
+    },
+    session({ session, token }) {
+      session.user.id = token.id
+      return session
+    },
+  },
 })

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,1 +1,5 @@
-export { auth as middleware } from "@/auth";
+import NextAuth from "next-auth"
+
+import authConfig from "@/auth.config"
+
+export const { auth: middleware } = NextAuth(authConfig)


### PR DESCRIPTION
Fixes #118

Fix the error 'PrismaClient is not configured to run in Edge Runtime' by implementing split configuration and extending the session.

* **Add `src/auth.config.ts`**: Add a common Auth.js configuration object without the database adapter.
* **Modify `src/auth.ts`**: Import `authConfig` from `./auth.config`, add `PrismaAdapter`, use jwt for the session strategy, and add callbacks to extend the session to include the user id.
* **Modify `src/middleware.ts`**: Import `authConfig` from `./auth.config` and instantiate its own Auth.js client without the database adapter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/119?shareId=b6613b8b-4ae1-48df-b804-6588681c1481).