### PR TITLE
Update zod safeParse using Object.fromEntries

### DIFF
--- a/src/models/todo.ts
+++ b/src/models/todo.ts
@@ -1,11 +1,22 @@
 import { Todo } from '@prisma/client';
 import { z } from 'zod';
 
+// checkbox states and form data
+// https://zenn.dev/fitness_densuke/articles/react_hook_form_checkbox_memo
+
+// checked true  => value (default: "on")
+// checked false => undefined
+// indeterminate => undefined
+
 export const TodoSchema = z.object({
   title: z.string().trim()
     .min(3, { message: 'Title must be at least 3 characters' })
     .max(10, { message: "Title mus be less than 10 characters for testing" }),
-  completed: z.boolean().optional(),
+  completed: z.string().optional()
+    .refine(val => val === 'on' || val === undefined, {
+      message: 'Expected checkbox value to be "on" or undefined',
+    })
+    .transform(val => val === 'on'),
 });
 
 export type TodoSchemaType = z.infer<typeof TodoSchema>;

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -18,7 +18,6 @@ export async function findAllTodos(): Promise<TodoFetchResponse> {
 
 export async function saveTodo(formData: FormData): Promise<TodoFormState> {
   const formObject = Object.fromEntries(formData.entries());
-
   const { data, success, error } = TodoSchema.safeParse(formObject);
 
   if (!success) {

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -1,5 +1,5 @@
 import { auth } from '@/auth';
-import { DeleteTodoState, TodoFetchResponse, TodoFormState, TodoSchema, TodoSchemaType } from '@/models/todo';
+import { DeleteTodoState, TodoFetchResponse, TodoFormState, TodoSchema } from '@/models/todo';
 import { createTodo, deleteTodoById, findAllByUserId } from '@/repositories/todo_repository';
 import { errorName, logPrismaError } from '@/utils/errorUtils';
 

--- a/src/services/todoService.ts
+++ b/src/services/todoService.ts
@@ -17,26 +17,23 @@ export async function findAllTodos(): Promise<TodoFetchResponse> {
 }
 
 export async function saveTodo(formData: FormData): Promise<TodoFormState> {
-  const data: TodoSchemaType = {
-    title: `${formData.get('title')}`,              // empty string if not defined
-    completed: formData.get('completed') === 'on',  // checkbox value is on/off
-  };
+  const formObject = Object.fromEntries(formData.entries());
 
-  const result = TodoSchema.safeParse(data);
+  const { data, success, error } = TodoSchema.safeParse(formObject);
 
-  if (!result.success) {
-    console.warn("server side validation error", result.error.flatten())
-    return { data, errors: result.error.flatten().fieldErrors };
+  if (!success) {
+    console.warn("server side validation error", error.flatten())
+    return { data, errors: error.flatten().fieldErrors };
   }
 
-  console.info(`Saving Todo: ${JSON.stringify(result.data)}`)
+  console.info(`Saving Todo: ${JSON.stringify(data)}`)
 
   const session = await auth();
   const userId = session?.user?.id;
 
   try {
-    await createTodo({ ...result.data, user: { connect: { id: userId } } });
-    return { data };
+    const created = await createTodo({ ...data, user: { connect: { id: userId } } });
+    return { data: created };
   } catch (e) {
     logPrismaError(e, "saveTodo");
     return { data, error: errorName(e) };


### PR DESCRIPTION
Fixes #120

Update zod safeParse process to use Object.fromEntries and modify TodoSchema.

* **src/models/todo.ts**
  - Update `completed` to `z.string().optional()`.
  - Add `.refine(val => val === 'on')` to `completed`.
  - Add `.transform(val => val === 'on')` to `completed`.

* **src/services/todoService.ts**
  - Replace `const data: TodoSchemaType` with `const formObject = Object.fromEntries(formData.entries());` in `saveTodo`.
  - Replace `const result = TodoSchema.safeParse(data);` with `const { data, success, error } = TodoSchema.safeParse(formObject);` in `saveTodo`.
  - Replace `result` with `data`, `success` or `error` in the following part of `saveTodo`.
  - Change `createTodo` return variable name to `created` to avoid conflict of `data` in `saveTodo`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/121?shareId=e1eb3f88-1378-4964-8258-4183ab1886e9).