### PR TITLE
Update prisma export to default

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -2,7 +2,7 @@ import { PrismaAdapter } from "@auth/prisma-adapter"
 import NextAuth from "next-auth"
 
 import authConfig from "@/lib/auth/auth.config"
-import { prisma } from "@/lib/prisma"
+import prisma from "@/lib/prisma"
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(prisma),

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,11 +1,15 @@
 import { PrismaClient } from "@prisma/client";
 
+// https://www.prisma.io/docs/orm/more/help-and-troubleshooting/nextjs-help
+
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
-export const prisma =
+const prisma =
   globalForPrisma.prisma || new PrismaClient();
 
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
 
-// This code is from the official documentation
-// https://www.prisma.io/docs/orm/more/help-and-troubleshooting/nextjs-help
+// export default for unit testing
+// https://www.prisma.io/docs/orm/prisma-client/testing/unit-testing#singleton
+// https://www.prisma.io/blog/testing-series-1-8eRB5p0Y8o#why-mock-prisma-client
+export default prisma;

--- a/src/repositories/todo-repository.ts
+++ b/src/repositories/todo-repository.ts
@@ -1,6 +1,6 @@
 import { Prisma, Todo } from '@prisma/client';
 
-import { prisma } from '@/lib/prisma';
+import prisma from '@/lib/prisma';
 
 // PrismaはfindManyやfindFirstはWhere句のクエリがundefinedの場合条件なしで検索する仕様なので注意
 // https://qiita.com/bon10/items/cb59c00fdd66ae880878


### PR DESCRIPTION
Fixes #132

Update `src/lib/prisma.ts` to export `prisma` as default and add documentation link.

* Export `prisma` as default in `src/lib/prisma.ts`.
* Add link to official Prisma documentation for unit testing in `src/lib/prisma.ts`.
* Update import of `prisma` to use default import in `src/lib/auth/auth.ts`.
* Update import of `prisma` to use default import in `src/repositories/todo-repository.ts`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/issues/132?shareId=XXXX-XXXX-XXXX-XXXX).