### PR TITLE
Setup Vitest for Prisma

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,3 +261,20 @@ npm install -D vitest @vitejs/plugin-react jsdom @testing-library/react @testing
 ```bash
 npx vitest run tests/sample.test.ts
 ```
+
+## Setup Vitest for Prisma
+
+1. Install the required package:
+
+```bash
+npm i -D vitest-mock-extended
+```
+
+2. Create `src/lib/__mocks__/prisma.ts`
+3. Create `tests/fixtures/test-data.ts`
+4. Create `tests/repositories/todo-repository.test.ts`
+5. Run the following command to execute your tests:
+
+```bash
+npm run test
+```

--- a/README.md
+++ b/README.md
@@ -264,6 +264,12 @@ npx vitest run tests/sample.test.ts
 
 ## Setup Vitest for Prisma
 
+* jest
+    - https://www.prisma.io/docs/orm/prisma-client/testing/unit-testing
+* vitest
+    - https://www.prisma.io/blog/testing-series-1-8eRB5p0Y8o
+    - https://www.prisma.io/blog/testing-series-2-xPhjjmIEsM#set-up-vitest
+
 1. Install the required package:
 
 ```bash
@@ -277,4 +283,6 @@ npm i -D vitest-mock-extended
 
 ```bash
 npm run test
+# or
+npm t
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "ts-node": "^10.9.2",
         "typescript": "^5",
         "vite-tsconfig-paths": "^5.1.4",
-        "vitest": "^3.0.7"
+        "vitest": "^3.0.7",
+        "vitest-mock-extended": "^3.0.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -8223,6 +8224,21 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-essentials": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-10.0.4.tgz",
+      "integrity": "sha512-lwYdz28+S4nicm+jFi6V58LaAIpxzhg9rLdgNC1VsdP/xiFBseGhF1M/shwCk6zMmwahBZdXcl34LVHrEang3A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8690,6 +8706,20 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest-mock-extended": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vitest-mock-extended/-/vitest-mock-extended-3.0.1.tgz",
+      "integrity": "sha512-VI7CRRvIi+MbAsqdGTxp3K+eiY7BR1zrVflZ5DBrFUXPjRZRgxXajlYdNyIu3v1bb5ZfdLANXwZ9i/RfVMfS6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-essentials": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "3.x || 4.x || 5.x",
+        "vitest": ">=3.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5",
     "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^3.0.7"
+    "vitest": "^3.0.7",
+    "vitest-mock-extended": "^3.0.1"
   }
 }

--- a/src/lib/__mocks__/prisma.ts
+++ b/src/lib/__mocks__/prisma.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from '@prisma/client';
+import { beforeEach, vi } from 'vitest';
+import { DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';
+
+import prisma from '@/lib/prisma';
+
+vi.mock("@/lib/prisma", () => ({
+  default: mockDeep<PrismaClient>(),
+}))
+
+beforeEach(() => {
+  mockReset(prismaMock)
+})
+
+const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>
+export default prismaMock;

--- a/src/lib/__mocks__/prisma.ts
+++ b/src/lib/__mocks__/prisma.ts
@@ -1,3 +1,6 @@
+// https://www.prisma.io/docs/orm/prisma-client/testing/unit-testing
+// https://www.prisma.io/blog/testing-series-1-8eRB5p0Y8o#why-mock-prisma-client
+
 import { PrismaClient } from '@prisma/client';
 import { beforeEach, vi } from 'vitest';
 import { DeepMockProxy, mockDeep, mockReset } from 'vitest-mock-extended';

--- a/tests/fixtures/test-data.ts
+++ b/tests/fixtures/test-data.ts
@@ -1,0 +1,31 @@
+import { Todo, User } from '@prisma/client';
+
+export const mockDate = new Date("2025-01-01T01:02:03+09:00");
+
+export const user1: User = {
+  id: "fake-user-id",
+  email: "user@prisma.io",
+  name: "Prisma Fan",
+  emailVerified: null,
+  image: null,
+  createdAt: mockDate,
+  updatedAt: mockDate,
+}
+
+export const todo1: Todo = {
+  id: 1,
+  title: "Buy apple",
+  completed: false,
+  userId: "user.id",
+  createdAt: mockDate,
+  updatedAt: mockDate,
+}
+
+export const todo2: Todo = {
+  id: 2,
+  title: "Buy banana",
+  completed: false,
+  userId: "user.id",
+  createdAt: mockDate,
+  updatedAt: mockDate,
+}

--- a/tests/repositories/todo-repository.test.ts
+++ b/tests/repositories/todo-repository.test.ts
@@ -1,0 +1,21 @@
+import { Prisma } from '@prisma/client';
+import { expect, test } from 'vitest';
+
+import prismaMock from '@/lib/__mocks__/prisma';
+import { createTodo } from '@/repositories/todo-repository';
+
+import { todo1 } from '../fixtures/test-data';
+
+// https://www.prisma.io/docs/orm/prisma-client/testing/unit-testing
+
+test('createTodo should return the new todo', async () => {
+  prismaMock.todo.create.mockResolvedValue(todo1)
+
+  const input: Prisma.TodoCreateInput = {
+    title: "Buy apple",
+    user: { connect: { email: "testing@example.com" } },
+  }
+  const createdTodo = await createTodo(input)
+
+  expect(createdTodo).toStrictEqual(todo1)
+})


### PR DESCRIPTION
Fixes #138

Add Vitest setup for Prisma according to the official documentation.

* Add `vitest` and `vitest-mock-extended` as dev dependencies in `package.json` and `package-lock.json`.
* Create `src/lib/__mocks__/prisma.ts` to mock Prisma Client using a singleton pattern.
* Create `tests/fixtures/test-data.ts` to provide mock data for testing.
* Create `tests/repositories/todo-repository.test.ts` to test the `createTodo` function.
* Update `README.md` to include instructions for setting up Vitest for Prisma and running tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/139?shareId=7262c528-2cc4-4305-a319-6ecccb90636c).