### PR TITLE
Setup Prisma read tests

### DIFF
--- a/src/repositories/todo-repository.ts
+++ b/src/repositories/todo-repository.ts
@@ -9,6 +9,15 @@ export async function createTodo(input: Prisma.TodoCreateInput): Promise<Todo> {
   return await prisma.todo.create({ data: { ...input } });
 }
 
+export async function getById(id: number, userId?: string) {
+  if (userId === undefined)
+    throw new RangeError("User ID is undefined");
+
+  return await prisma.todo.findUniqueOrThrow({
+    where: { id, userId },
+  });
+}
+
 export async function findAllByUserId(userId?: string, orderBy: keyof Todo = 'createdAt'): Promise<Todo[]> {
   if (userId === undefined)
     throw new RangeError("User ID is undefined");

--- a/tests/fixtures/test-data.ts
+++ b/tests/fixtures/test-data.ts
@@ -1,4 +1,4 @@
-import { Todo, User } from '@prisma/client';
+import { Prisma, Todo, User } from '@prisma/client';
 
 export const mockDate = new Date("2025-01-01T01:02:03+09:00");
 
@@ -29,3 +29,12 @@ export const todo2: Todo = {
   createdAt: mockDate,
   updatedAt: mockDate,
 }
+
+// https://www.prisma.io/docs/orm/reference/error-reference#p2025
+const cause = "Expected a record, found none.";
+const messageP2025 = ("An operation failed because it depends on "
+  + `one or more records that were required but not found. ${cause}`)
+
+export const mock_not_found_error = new Prisma.PrismaClientKnownRequestError(
+  messageP2025, { code: "P2025", clientVersion: "mock-client-version" }
+);

--- a/tests/repositories/todo-repository.test.ts
+++ b/tests/repositories/todo-repository.test.ts
@@ -2,9 +2,9 @@ import { Prisma } from '@prisma/client';
 import { expect, test } from 'vitest';
 
 import prismaMock from '@/lib/__mocks__/prisma';
-import { createTodo } from '@/repositories/todo-repository';
+import { createTodo, getById, findAllByUserId } from '@/repositories/todo-repository';
 
-import { todo1 } from '../fixtures/test-data';
+import { mock_not_found_error, todo1, todo2 } from '../fixtures/test-data';
 
 // https://www.prisma.io/docs/orm/prisma-client/testing/unit-testing
 
@@ -18,4 +18,36 @@ test('createTodo should return the new todo', async () => {
   const createdTodo = await createTodo(input)
 
   expect(createdTodo).toStrictEqual(todo1)
+})
+
+test('getById should return the todo with the given id', async () => {
+  prismaMock.todo.findUniqueOrThrow.mockResolvedValue(todo1)
+
+  const todo = await getById(todo1.id, "fake-user-id")
+
+  expect(todo).toStrictEqual(todo1)
+  expect(prismaMock.todo.findUniqueOrThrow).toHaveBeenCalledWith({
+    where: { id: todo1.id, userId: "fake-user-id" }
+  })
+})
+
+test('getById should throw mock_not_found_error when todo is not found', async () => {
+  prismaMock.todo.findUniqueOrThrow.mockRejectedValue(mock_not_found_error)
+
+  await expect(getById(999, "fake-user-id")).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
+})
+
+test('findAllByUserId should return all todos for the given user id', async () => {
+  prismaMock.todo.findMany.mockResolvedValueOnce([todo1])
+  prismaMock.todo.findMany.mockResolvedValueOnce([todo1, todo2])
+
+  // first time call
+  const todos = await findAllByUserId(todo1.userId)
+
+  expect(todos).toStrictEqual([todo1])
+
+  // second time call
+  const todos2 = await findAllByUserId("fake-user-id")
+
+  expect(todos2).toStrictEqual([todo1, todo2])
 })


### PR DESCRIPTION
Fixes #142

Add `getById` function and corresponding tests for `todo-repository`.

* **`src/repositories/todo-repository.ts`**
  - Add `getById` function to retrieve a todo by its ID.

* **`tests/fixtures/test-data.ts`**
  - Add `MockNofFoundError` as a mock of `NotFoundError`.
  - MockNofFoundError is a `Prisma.PrismaClientKnownRequestError` with prisma error code `P2025`.

* **`tests/repositories/todo-repository.test.ts`**
  - Add `getById` test using `todo1` mock data.
  - Add `getById` test with `prismaMock` throwing `MockNofFoundError`.
  - Add `findAllByUserId` test using `todo1` and `todo2` mock data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/143?shareId=05930a76-a2e6-49e4-95df-11044c67aa2e).