### PR TITLE
Add service tests

### DIFF
--- a/tests/fixtures/setup-mocks.ts
+++ b/tests/fixtures/setup-mocks.ts
@@ -1,0 +1,18 @@
+import { Session } from 'next-auth';
+import { vi } from 'vitest';
+
+// Vitest Guide Mocking: https://vitest.dev/guide/mocking
+
+const mockSession: Session = {
+  user: {
+    id: 'mock-user-id',
+    name: 'Mock User',
+    email: 'mockuser@example.com',
+    image: 'mock-user-image'
+  },
+  expires: '1h',
+};
+
+vi.mock('@/lib/auth/auth', () => ({
+  auth: vi.fn(() => mockSession),
+}));

--- a/tests/repositories/todo-repository.test.ts
+++ b/tests/repositories/todo-repository.test.ts
@@ -2,7 +2,7 @@ import { Prisma } from '@prisma/client';
 import { expect, test } from 'vitest';
 
 import prismaMock from '@/lib/__mocks__/prisma';
-import { createTodo, getById, findAllByUserId } from '@/repositories/todo-repository';
+import { createTodo, findAllByUserId, getById } from '@/repositories/todo-repository';
 
 import { mock_not_found_error, todo1, todo2 } from '../fixtures/test-data';
 
@@ -26,15 +26,17 @@ test('getById should return the todo with the given id', async () => {
   const todo = await getById(todo1.id, "fake-user-id")
 
   expect(todo).toStrictEqual(todo1)
-  expect(prismaMock.todo.findUniqueOrThrow).toHaveBeenCalledWith({
-    where: { id: todo1.id, userId: "fake-user-id" }
-  })
+  expect(prismaMock.todo.findUniqueOrThrow)
+    .toHaveBeenCalledWith({
+      where: { id: todo1.id, userId: "fake-user-id" }
+    })
 })
 
 test('getById should throw mock_not_found_error when todo is not found', async () => {
   prismaMock.todo.findUniqueOrThrow.mockRejectedValue(mock_not_found_error)
 
-  await expect(getById(999, "fake-user-id")).rejects.toThrow(Prisma.PrismaClientKnownRequestError)
+  await expect(getById(999, "fake-user-id"))
+    .rejects.toThrow(Prisma.PrismaClientKnownRequestError)
 })
 
 test('findAllByUserId should return all todos for the given user id', async () => {

--- a/tests/services/todo-service.test.ts
+++ b/tests/services/todo-service.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest';
+
+import prismaMock from '@/lib/__mocks__/prisma';
+import { findAllTodos } from '@/services/todo-service';
+
+import { todo1, todo2 } from '../fixtures/test-data';
+
+test('findAllTodos should return all todos for the authenticated user', async () => {
+  prismaMock.todo.findMany.mockResolvedValue([todo1, todo2]);
+
+  const result = await findAllTodos();
+
+  expect(result.data).toStrictEqual([todo1, todo2]);
+  expect(result.error).toBeUndefined();
+});
+
+test('findAllTodos should return an error if no todos are found', async () => {
+  prismaMock.todo.findMany.mockResolvedValue([]);
+
+  const result = await findAllTodos();
+
+  expect(result.data).toStrictEqual([]);
+  expect(result.error).toBeUndefined();
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,10 +6,17 @@ export default defineConfig({
   plugins: [tsconfigPaths(), react()],
   test: {
     environment: 'jsdom',
+    setupFiles: [
+      "tests/fixtures/setup-mocks.ts",
+    ],
+    // https://vitest.dev/guide/coverage
     coverage: {
       enabled: true,
       include: [
         "src",
+      ],
+      exclude: [
+        "src/lib/__mocks__",
       ],
       extension: [
         ".ts",


### PR DESCRIPTION
Fixes #144

Add service tests for `findAllTodos` of `@/services/todo-service`.

* Create `tests/fixtures/setup-mocks.ts` to set up a mock of `"@/lib/auth/auth"` to return a mock session of 'next-auth'.
* Update `vitest.config.mts` to use `tests/fixtures/setup-mocks.ts` as its setupFiles and to exclude `"src/lib/__mocks__"` from coverage.
* Create `tests/services/todo-service.test.ts` to include tests for `findAllTodos` of `@/services/todo-service`.
* Update `tests/repositories/todo-repository.test.ts` import order to `createTodo, findAllByUserId, getById`.
* Add new lines in `tests/repositories/todo-repository.test.ts` where the line is too long.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/145?shareId=2d019403-515a-4d2b-9acd-3dd9fa6b78c8).