### PR TITLE
Update findAllTodos service test

### DIFF
--- a/tests/fixtures/test-data.ts
+++ b/tests/fixtures/test-data.ts
@@ -30,6 +30,17 @@ export const todo2: Todo = {
   updatedAt: mockDate,
 }
 
+// https://www.prisma.io/docs/orm/reference/error-reference#p1001
+const messageP1001 = (
+  "Can't reach database server at {database_host}:{database_port}"
+  + " Please make sure your database server is running"
+  + " at {database_host}:{database_port}."
+);
+
+export const mock_cannot_reach_database_error = new Prisma.PrismaClientKnownRequestError(
+  messageP1001, { code: "P1001", clientVersion: "mock-client-version" }
+);
+
 // https://www.prisma.io/docs/orm/reference/error-reference#p2025
 const cause = "Expected a record, found none.";
 const messageP2025 = ("An operation failed because it depends on "

--- a/tests/services/todo-service.test.ts
+++ b/tests/services/todo-service.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import prismaMock from '@/lib/__mocks__/prisma';
 import { findAllTodos } from '@/services/todo-service';
 
-import { todo1, todo2 } from '../fixtures/test-data';
+import { todo1, todo2, mock_cannot_reach_database_error } from '../fixtures/test-data';
 
 test('findAllTodos should return all todos for the authenticated user', async () => {
   prismaMock.todo.findMany.mockResolvedValue([todo1, todo2]);
@@ -15,10 +15,10 @@ test('findAllTodos should return all todos for the authenticated user', async ()
 });
 
 test('findAllTodos should return an error if no todos are found', async () => {
-  prismaMock.todo.findMany.mockResolvedValue([]);
+  prismaMock.todo.findMany.mockRejectedValue(mock_cannot_reach_database_error);
 
   const result = await findAllTodos();
 
-  expect(result.data).toStrictEqual([]);
-  expect(result.error).toBeUndefined();
+  expect(result.data).toBeUndefined();
+  expect(result.error).toBe(mock_cannot_reach_database_error.name);
 });


### PR DESCRIPTION
Fixes #150

Update the test 'findAllTodos should return an error if no todos are found' to use and verify the `mock_cannot_reach_database_error`.

* Add `mock_cannot_reach_database_error` as a `Prisma.PrismaClientKnownRequestError` with code "P1001" in `tests/fixtures/test-data.ts`.
* Update the test 'findAllTodos should return an error if no todos are found' in `tests/services/todo-service.test.ts` to mock `mock_cannot_reach_database_error`.
* Verify that the error returned by `findAllTodos` matches `mock_cannot_reach_database_error`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/151?shareId=03b95146-120b-418c-94cf-15d8693e9d5a).