### PR TITLE
Fix Home logic

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,16 +6,17 @@ export default async function Home() {
   const session = await auth();
   const userId = session?.user?.id;
 
-  if (!userId) {
-    return (
-      <div className="container">
-        <main className="main">
-          <h1>Welcome to the Todo App</h1>
-          <p>Please log in to access your todos.</p>
-        </main>
-      </div>
-    );
+  if (userId) {
+    redirect('/todos');
+    return;
   }
 
-  redirect('/todos');
+  return (
+    <div className="container">
+      <main className="main">
+        <h1>Welcome to the Todo App</h1>
+        <p>Please log in to access your todos.</p>
+      </main>
+    </div>
+  );
 }

--- a/tests/services/todo-service.test.ts
+++ b/tests/services/todo-service.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import prismaMock from '@/lib/__mocks__/prisma';
 import { findAllTodos } from '@/services/todo-service';
 
-import { todo1, todo2, mock_cannot_reach_database_error } from '../fixtures/test-data';
+import { mock_cannot_reach_database_error, todo1, todo2 } from '../fixtures/test-data';
 
 test('findAllTodos should return all todos for the authenticated user', async () => {
   prismaMock.todo.findMany.mockResolvedValue([todo1, todo2]);


### PR DESCRIPTION
Fixes #152

Simplify the logic in `src/app/page.tsx` to avoid widely opened if statements.

* Replace the if statement with an early return if `userId` exists.
* Redirect to the `/todos` page if `userId` exists.
* Return a JSX element with a welcome message and a prompt to log in if `userId` does not exist.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/153?shareId=002efb64-581d-48db-8e19-1ba5f28cee14).