### PR TITLE
Add about page with e2e test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,6 +14,7 @@ jobs:
       with:
         node-version: lts/*
     - name: Cache Playwright Browsers
+      id: playwright-cache
       uses: actions/cache@v4
       with:
         path: ~/.cache/ms-playwright
@@ -24,6 +25,7 @@ jobs:
       run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
     - name: Run Auth Secret
       run: npx auth secret
     - name: Run Playwright tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -17,6 +17,8 @@ jobs:
       run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
+    - name: Run Auth Secret
+      run: npx auth secret
     - name: Run Playwright tests
       run: npx playwright test
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,13 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version: lts/*
+    - name: Cache Playwright Browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -26,6 +26,8 @@ jobs:
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
       if: steps.playwright-cache.outputs.cache-hit != 'true'
+    - run: npx playwright install-deps
+      if: steps.playwright-cache.outputs.cache-hit == 'true'
     - name: Run Auth Secret
       run: npx auth secret
     - name: Run Playwright tests

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,7 +14,6 @@ jobs:
       with:
         node-version: lts/*
     - name: Cache Playwright Browsers
-      id: playwright-cache
       uses: actions/cache@v4
       with:
         path: ~/.cache/ms-playwright
@@ -25,9 +24,6 @@ jobs:
       run: npm ci
     - name: Install Playwright Browsers
       run: npx playwright install --with-deps
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-    - run: npx playwright install-deps
-      if: steps.playwright-cache.outputs.cache-hit == 'true'
     - name: Run Auth Secret
       run: npx auth secret
     - name: Run Playwright tests

--- a/e2e/about.spec.ts
+++ b/e2e/about.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "@playwright/test";
+
+// Creating your first Playwright E2E test
+// https://nextjs.org/docs/app/building-your-application/testing/playwright
+
+test("should navigate to the about page", async ({ page }) => {
+  // Start from the index page (the baseURL is set via the webServer in the playwright.config.ts)
+  await page.goto("http://localhost:3000/");
+  // Find an element with the text 'About' and click on it
+  await page.click("text=About");
+  // The new URL should be "/about" (baseURL is used there)
+  await expect(page).toHaveURL("http://localhost:3000/about");
+  // The new page should contain an h1 with "About"
+  await expect(page.locator("h1")).toContainText("About");
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -71,9 +71,9 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -72,8 +72,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npm run dev',
-    url: 'http://127.0.0.1:3000',
+    command: "npm run dev",
+    url: "http://127.0.0.1:3000",
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,12 @@
+import Link from "next/link";
+
+export default function Page() {
+  return (
+    <div className="container">
+      <main className="main">
+        <h1>About</h1>
+        <Link href="/">Home</Link>
+      </main>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 
 import { auth } from "@/lib/auth/auth";
@@ -15,6 +16,7 @@ export default async function Home() {
       <main className="main">
         <h1>Welcome to the Todo App</h1>
         <p>Please log in to access your todos.</p>
+        <Link href="/about">About</Link>
       </main>
     </div>
   );


### PR DESCRIPTION
Fixes #162

Add about page and e2e test for it

* Create a new about page component at `src/app/about/page.tsx` that returns a simple message and a link to the Home page.
* Add a link to the about page in the Home page component in `src/app/page.tsx`.
* Create a new e2e test file for the about page in `e2e/about.spec.ts` that navigates to the about page and checks for the message.
* Uncomment the `webServer` part in `playwright.config.ts` to enable running the local dev server before starting the tests.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/163?shareId=03c5b27a-5003-4b45-a436-988efa78e3d7).