### PR TITLE
Speed up playwright github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: lts/*
           cache: 'npm'
       - run: npm ci
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,74 +1,30 @@
 name: Playwright Tests
+
+# https://zenn.dev/k2wanko/articles/60c195cc4bff0a
+
 on:
   push:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
   workflow_dispatch:
+
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: docker/setup-buildx-action@v3
+    - uses: docker/build-push-action@v6
       with:
-        node-version: lts/*
+        load: true
+        push: false
+        tags: nextjs15-todo-example:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+    - name: Run Playwright tests in Docker container
+      run: docker run --rm nextjs15-todo-example:latest
 
-    - name: Cache Playwright Browsers
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-playwright-
-    - name: Cache apt archives
-      id: cache-apt
-      uses: actions/cache/restore@v4
-      with:
-        path: ~/apt-archives
-        key: ${{ runner.os }}-apt-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-apt-
-
-    - name: Install dependencies
-      run: npm ci
-
-    - name: Install Playwright Dependencies (Dry Run)
-      run: npx playwright install-deps chromium --dry-run
-    - name: Set package variable from dry run
-      id: packages
-      run: echo "PACKAGES=$(npx playwright install-deps chromium --dry-run | grep -oP '(?<=install -y --no-install-recommends ).*[^"]')" >> $GITHUB_OUTPUT
-
-    - name: Create apt archives partial directory
-      if: steps.cache-apt.outputs.cache-hit != 'true'
-      run: mkdir -p ~/apt-archives/partial
-    - name: Download apt packages
-      if: steps.cache-apt.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update -o Dir::Cache::Archives=/home/runner/apt-archives
-        sudo apt-get install --download-only -o Dir::Cache::Archives=/home/runner/apt-archives ${{ steps.packages.outputs.PACKAGES }}
-
-    - name: Install apt packages from cache
-      run: |
-        sudo chown -Rv _apt /home/runner/apt-archives
-        sudo apt-get install -o Dir::Cache::Archives=/home/runner/apt-archives ${{ steps.packages.outputs.PACKAGES }}
-        sudo chown -Rv runner /home/runner/apt-archives
-    - name: Save cache apt archives in main branch
-      uses: actions/cache/save@v4
-      if: |
-        github.ref_name == 'main' &&
-        steps.cache-apt.outputs.cache-hit != 'true'
-      with:
-        path: ~/apt-archives
-        key: ${{ runner.os }}-apt-${{ hashFiles('**/package-lock.json') }}
-
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps --no-shell chromium
-    - name: Run Auth Secret
-      run: npx auth secret
-    - name: Run Playwright tests
-      run: npx playwright test --project=chromium
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:22-bookworm
+
+# run Playwright inside Docker
+# https://playwright.dev/docs/docker#build-your-own-image
+
+RUN npx -y playwright@1.51.1 install --with-deps
+
+WORKDIR /app
+
+COPY package.json package-lock.json /app/
+
+RUN npm ci
+
+COPY \
+    eslint.config.mjs \
+    next.config.ts \
+    playwright.config.ts \
+    postcss.config.mjs \
+    tailwind.config.ts \
+    tsconfig.json \
+    vitest.config.mts \
+    /app/
+
+COPY prisma/ /app/prisma/
+COPY public/ /app/public/
+
+RUN npx auth secret && npx prisma generate
+
+COPY e2e/ /app/e2e/
+COPY src/ /app/src/
+
+CMD [ "npx", "playwright", "test", "--reporter=list" ]

--- a/README.md
+++ b/README.md
@@ -408,3 +408,26 @@ npx playwright codegen
 ```bash
 npm install -D @playwright/test@latest
 ```
+
+## Docker Playwright
+
+* run Playwright scripts in Docker environment
+    - https://playwright.dev/docs/docker
+
+```bash
+docker pull mcr.microsoft.com/playwright:v1.51.1-noble
+
+docker run -it --rm --ipc=host mcr.microsoft.com/playwright:v1.51.1-noble /bin/bash
+```
+
+* sample configurations for common CI providers
+    - https://playwright.dev/docs/ci#github-actions
+
+```bash
+docker build -t nextjs15-todo-example .
+
+docker run nextjs15-todo-example
+
+# debug
+docker run -it nextjs15-todo-example bash
+```


### PR DESCRIPTION
Fixes #168

Add Dockerfile to run Playwright e2e tests in a Docker environment.

* **Dockerfile**
  - Add a Dockerfile to set up the environment for running Playwright e2e tests.
  - Use the official Node.js image as the base image.
  - Install necessary dependencies including Playwright and its browsers.
  - Copy the application code into the Docker image.
  - Set the default command to run the Playwright tests.

* **README.md**
  - Add a section on running Playwright scripts in a Docker environment.
  - Include a link to the Playwright documentation for Docker.
  - Include a link to sample configurations for common CI providers.
  - Add instructions for building the Docker image in GitHub Actions.

* **.github/workflows/playwright.yml**
  - Add steps to build the Docker image using the Dockerfile.
  - Update the job to run the Playwright tests inside the Docker container.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/169?shareId=ff9cb73e-06b2-4a2e-98be-90a93ef477b6).