### PR TITLE
Consolidate compose files into docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,9 +424,9 @@ docker run -it --rm --ipc=host mcr.microsoft.com/playwright:v1.51.1-noble /bin/b
     - https://playwright.dev/docs/ci#github-actions
 
 ```bash
-docker build -t nextjs15-todo-example .
+docker compose build app
 
-docker run nextjs15-todo-example
+docker compose up app
 
 # debug
 docker run -it nextjs15-todo-example bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,0 @@
-services:
-  app:
-    image: nextjs15-todo-example:latest
-    build:
-      context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,10 @@ services:
     working_dir: /app
     stdin_open: true # Keeps stdin open in case any prompts happen
     tty: true # Allocates a pseudo-terminal for output formatting
+  app:
+    image: nextjs15-todo-example:latest
+    build:
+      context: .
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Fixes #172

Move the content from `compose.yaml` to `docker-compose.yml` and remove `compose.yaml`.

* Add the `app` service definition from `compose.yaml` to `docker-compose.yml` under the `services` section.
* Ensure the `app` service uses the `nextjs15-todo-example:latest` image and builds from the current context.
* Remove `compose.yaml` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kenfj/nextjs15-todo-example/pull/173?shareId=277bb245-6c37-42a1-9389-d502c52d378b).